### PR TITLE
fix: resolve ruff lint errors (E741 ambiguous vars, W293 whitespace, …

### DIFF
--- a/tokenmizer/api/app.py
+++ b/tokenmizer/api/app.py
@@ -765,8 +765,9 @@ async def get_graph_obsidian(session_id: str):
     Download graph as Obsidian Canvas (.canvas) file.
     Save as <any-name>.canvas inside your Obsidian vault and open directly.
     """
-    from fastapi.responses import Response as _Resp
     import json as _json
+
+    from fastapi.responses import Response as _Resp
     graph = await _get_graph_async(session_id)
     canvas = graph.to_obsidian_canvas()
     filename = f"tokenmizer-{session_id[:12]}.canvas"

--- a/tokenmizer/checkpoints/manager.py
+++ b/tokenmizer/checkpoints/manager.py
@@ -178,7 +178,7 @@ class CheckpointManager:
 
     def _build_critical(self, graph: GraphMemory, next_action: str) -> str:
         """~100 tokens. Only open blockers + critical decisions."""
-        from tokenmizer.graph_memory.graph import NodeType, NodeStatus
+        from tokenmizer.graph_memory.graph import NodeStatus, NodeType
         lines = []
 
         open_errors = [n for n in graph._nodes.values()
@@ -214,7 +214,7 @@ class CheckpointManager:
 
     def _build_full(self, graph: GraphMemory, messages: list[dict], next_action: str) -> str:
         """~600 tokens. Deep resume with environment, schemas, dependencies."""
-        from tokenmizer.graph_memory.graph import NodeType, NodeStatus
+        from tokenmizer.graph_memory.graph import NodeStatus, NodeType
         parts = [self._build_standard(graph, "")]
 
         env_nodes = [n for n in graph._nodes.values() if n.type == NodeType.ENVIRONMENT]

--- a/tokenmizer/compression/engine.py
+++ b/tokenmizer/compression/engine.py
@@ -309,7 +309,7 @@ class FileContentFilter:
 
     def filter_csv(self, content: str) -> str:
         """Send schema + first N rows instead of full CSV."""
-        lines = [l for l in content.splitlines() if l.strip()]
+        lines = [line for line in content.splitlines() if line.strip()]
         if len(lines) <= self.MAX_CSV_ROWS + 1:
             return content
         header = lines[0]

--- a/tokenmizer/compression/output_trimmer.py
+++ b/tokenmizer/compression/output_trimmer.py
@@ -58,11 +58,11 @@ class OutputTrimmer:
     def trim(self, text: str, level: str = "standard") -> tuple[str, int]:
         """
         Remove structural filler from LLM output.
-        
+
         Args:
             text: raw LLM response
             level: "lite" (openings only) | "standard" | "aggressive"
-        
+
         Returns:
             (trimmed_text, tokens_saved)
         """

--- a/tokenmizer/compression/window.py
+++ b/tokenmizer/compression/window.py
@@ -52,7 +52,7 @@ class SmartMessageWindow:
     ) -> tuple[list[dict], int]:
         """
         Apply smart windowing to messages.
-        
+
         Returns:
             (windowed_messages, tokens_saved)
         """

--- a/tokenmizer/filters/file_intelligence.py
+++ b/tokenmizer/filters/file_intelligence.py
@@ -414,9 +414,9 @@ class JSONExtractor:
             data = json.loads(content)
         except json.JSONDecodeError:
             # Try JSONL
-            lines = [l.strip() for l in content.splitlines() if l.strip()]
+            lines = [line.strip() for line in content.splitlines() if line.strip()]
             try:
-                data = [json.loads(l) for l in lines[:1000]]
+                data = [json.loads(line) for line in lines[:1000]]
             except Exception:
                 truncated, was_cut = _truncate_to_budget(content, token_budget)
                 return FileExtractionResult(
@@ -474,7 +474,7 @@ class JSONExtractor:
         elif isinstance(data, list) and data:
             lines.append(f"  {prefix}[]: array({len(data)})")
             lines.append(self._extract_schema(data[0], f"{prefix}[]", max_depth, depth + 1))
-        return "\n".join(l for l in lines if l)
+        return "\n".join(line for line in lines if line)
 
 
 # ── PDF extractor ─────────────────────────────────────────────────────────────
@@ -810,7 +810,7 @@ class TextExtractor:
 class FileIntelligence:
     """
     Main entry point. Auto-detects file type and applies correct strategy.
-    
+
     Usage in app.py:
         fi = FileIntelligence()
         result = fi.process(content, filename, token_budget=500, query=user_query)
@@ -834,7 +834,7 @@ class FileIntelligence:
     ) -> FileExtractionResult:
         """
         Process any file. Returns extracted content within token_budget.
-        
+
         Args:
             content: raw file bytes or text string
             filename: original filename (used for type detection)
@@ -875,7 +875,7 @@ class FileIntelligence:
         Detects patterns like:
           - "Here is my CSV file: <large content>"
           - Multi-line data blocks embedded in user messages
-        
+
         Returns (processed_messages, total_tokens_saved)
         """
         total_saved = 0
@@ -949,8 +949,8 @@ class FileIntelligence:
                 start += 1
 
             sample = lines[start:start + 5]
-            comma_counts = [l.count(",") for l in sample if l]
-            tab_counts = [l.count("\t") for l in sample if l]
+            comma_counts = [line.count(",") for line in sample if line]
+            tab_counts = [line.count("\t") for line in sample if line]
             avg_commas = sum(comma_counts) / max(1, len(comma_counts))
             avg_tabs = sum(tab_counts) / max(1, len(tab_counts))
 

--- a/tokenmizer/graph_memory/decision_tracker.py
+++ b/tokenmizer/graph_memory/decision_tracker.py
@@ -126,17 +126,17 @@ def find_contradicting_decisions(
     """
     Find existing decision nodes that cover the same topic as the new decision.
     Returns list of node IDs to mark as SUPERSEDED (history preserved, never deleted).
-    
+
     Only returns decisions that:
     1. Are currently COMPLETED (active)
     2. Cover the same topic bucket
     3. Are NOT the same decision (not a duplicate)
-    
+
     Args:
         new_label: label of the incoming decision
         new_summary: rationale of the incoming decision
         existing_nodes: current graph nodes
-    
+
     Returns:
         List of node IDs to supersede
     """

--- a/tokenmizer/graph_memory/graph.py
+++ b/tokenmizer/graph_memory/graph.py
@@ -30,18 +30,18 @@ import time
 from dataclasses import asdict
 from pathlib import Path
 
-from tokenmizer.graph_memory.types import (
-    NodeType,
-    NodeStatus,
-    EdgeType,
-    MemoryNode,
-    MemoryEdge,
-    DecisionTransition,
-)
 from tokenmizer.graph_memory.helpers import (
     _content_to_text,
-    _infer_trigger,
     _extract_evidence_from_text,
+    _infer_trigger,
+)
+from tokenmizer.graph_memory.types import (
+    DecisionTransition,
+    EdgeType,
+    MemoryEdge,
+    MemoryNode,
+    NodeStatus,
+    NodeType,
 )
 
 __all__ = [

--- a/tokenmizer/graph_memory/validator.py
+++ b/tokenmizer/graph_memory/validator.py
@@ -68,12 +68,12 @@ class ValidationResult:
 class GraphValidator:
     """
     Validates and scores node candidates before graph insertion.
-    
+
     Confidence scoring:
       - starts at 0.5 (neutral)
       - boosted by: specific language, file paths, keywords, context
       - penalised by: short labels, generic words, noise patterns
-    
+
     Threshold: accept if confidence >= 0.5 (configurable)
     """
 


### PR DESCRIPTION
…I001 import sorting)

## What this PR does

<!-- Brief description -->

## Type
- [ ] Bug fix
- [ ] Extraction improvement (graph_memory/)
- [ ] New provider
- [ ] Performance
- [ ] Documentation

## Tests
- [ ] `pytest tests/ -v` passes
- [ ] `ruff check tokenmizer/` clean
- [ ] Memory accuracy test added/updated (if extraction change)

## Checklist
- [ ] No raw dicts crossing layer boundaries (use DTOs)
- [ ] No `os.getenv()` outside `config/settings.py`
- [ ] External imports are lazy (inside functions, with try/except ImportError)
