### PR TITLE
feat: true SSE streaming passthrough (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.3.0] — 2026-07-02 — true SSE streaming
+
+- **`stream: true` now works** — real passthrough streaming in OpenAI
+  `chat.completion.chunk` SSE format for Anthropic, OpenAI, DeepSeek,
+  Mistral, OpenRouter, Grok (OpenAI-compatible base) and Ollama. Cursor,
+  Continue.dev and every streaming client can now point at TokenMizer
+  without config changes.
+- All input-side layers (file intelligence, compression, graph memory,
+  context injection) apply to streamed requests; output trimming is
+  skipped in stream mode by design. Cache hits stream as a single chunk;
+  post-stream analytics + cache writes preserved.
+- Providers without passthrough support return an explicit 501 (never a
+  fake buffered stream). Mid-stream provider failures emit an SSE `error`
+  event instead of silently truncating.
+
 ## [0.2.6] — 2026-07-02 — MCP registry readiness
 
 - NEW console script `tokenmizer-mcp` — runs the MCP stdio server directly

--- a/README.md
+++ b/README.md
@@ -130,13 +130,9 @@ response = client.chat.completions.create(
 )
 ```
 
-> **⚠️ Streaming is not supported yet.** Set `stream: false` (or leave it unset —
-> that's the default) in every request. Requests with `stream: true` return
-> `HTTP 501`. True SSE streaming is planned for v0.3.
->
-> **Cursor:** Settings → Models → your model entry → disable "Stream responses"
-> **Continue.dev:** in `config.json`, set `"streamResponses": false` for the
-> TokenMizer provider entry
+> ✅ **Streaming works** (v0.3+): `stream: true` gives real SSE passthrough for
+> Anthropic, OpenAI, DeepSeek, Mistral, OpenRouter, Grok and Ollama. Cursor and
+> Continue.dev work with default settings — no config changes needed.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenmizer"
-version = "0.2.6"
+version = "0.3.0"
 description = "Reduce AI context loss by 2x. Graph-backed checkpoint and resume for any LLM session."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/integration/test_api_endpoint.py
+++ b/tests/integration/test_api_endpoint.py
@@ -126,7 +126,40 @@ class TestChatCompletionsE2E:
         assert kwargs.get("temperature") == 0.0
         assert kwargs.get("top_p") == 0.9
 
-    def test_stream_returns_501_with_clear_message(self, client):
+    def test_streaming_returns_sse_chunks(self, client):
+        """v0.3: stream=true must return true SSE passthrough in OpenAI
+        chat.completion.chunk format, ending with data: [DONE]."""
+        c, fake = client
+
+        async def fake_stream(**kwargs):
+            for piece in ("Hello", " streamed", " world"):
+                yield piece
+
+        fake.chat_stream = fake_stream
+        r = c.post("/v1/chat/completions", json={
+            "messages": [{"role": "user", "content": "stream me a story please"}],
+            "stream": True,
+        })
+        assert r.status_code == 200, r.text
+        assert "text/event-stream" in r.headers["content-type"]
+        body = r.text
+        assert "chat.completion.chunk" in body
+        assert '"content": "Hello"' in body
+        assert '"content": " streamed"' in body
+        assert '"finish_reason": "stop"' in body
+        assert body.rstrip().endswith("data: [DONE]")
+
+    def test_streaming_unsupported_provider_returns_501(self, client, monkeypatch):
+        """Providers without chat_stream override must get a clear 501,
+        not a fake buffered stream."""
+        from tokenmizer.api import app as app_module
+        from tokenmizer.providers.providers import BaseProvider
+
+        class NoStreamProvider(BaseProvider):
+            async def _call(self, *a, **k):  # pragma: no cover
+                raise NotImplementedError
+
+        monkeypatch.setattr(app_module, "_get_provider", lambda: NoStreamProvider())
         c, _ = client
         r = c.post("/v1/chat/completions", json={
             "messages": [{"role": "user", "content": "hi"}],

--- a/tokenmizer/__init__.py
+++ b/tokenmizer/__init__.py
@@ -1,6 +1,6 @@
 """TokenMizer — Never lose your AI context again."""
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 __all__ = ["GraphMemory", "CheckpointManager", "get_settings"]
 
 

--- a/tokenmizer/api/app.py
+++ b/tokenmizer/api/app.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel
 
 from tokenmizer.analytics.engine import AnalyticsEngine
@@ -261,7 +261,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="TokenMizer",
     description="Never lose your AI context again.",
-    version="0.2.6",
+    version="0.3.0",
     lifespan=lifespan,
     docs_url="/docs",
     redoc_url="/redoc",
@@ -558,17 +558,6 @@ async def _call_provider(
             output_tokens = count_tokens(cached.response, model)
             return cached.response, 0, output_tokens, 0.0
 
-    # Streaming check
-    if req.stream:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                "Streaming is not yet supported by the TokenMizer proxy. "
-                "Set stream=False in your request, or connect directly to "
-                "your provider for streaming. True SSE streaming is planned for v0.3."
-            ),
-        )
-
     # LLM call
     # NOTE: `messages` is already redacted — redaction now happens once at
     # ingestion in chat_completions() so every downstream consumer (this call,
@@ -607,6 +596,83 @@ async def _call_provider(
                    session_id=session_id)
 
     return response_text, input_tokens, output_tokens, latency_ms
+
+
+def _stream_response(req, messages, model, user_content, session_id,
+                     savings, orig_input_tokens) -> StreamingResponse:
+    """True SSE passthrough (OpenAI chat.completion.chunk format).
+
+    Cache hits stream as a single chunk. After the stream closes, analytics
+    and the semantic-cache write run on the accumulated text — same
+    bookkeeping as the non-stream path, minus output trimming.
+    """
+    import json as _json
+
+    from tokenmizer.providers.providers import BaseProvider, ProviderError
+
+    provider = _get_provider()
+    if getattr(type(provider), "chat_stream", None) is BaseProvider.chat_stream:
+        raise HTTPException(
+            status_code=501,
+            detail=(f"Streaming passthrough is not implemented for provider "
+                    f"'{settings.provider}' yet (supported: anthropic, openai, "
+                    f"deepseek, mistral, openrouter, grok, ollama). "
+                    f"Set stream=false for this provider."),
+        )
+
+    resp_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+    created = int(time.time())
+
+    def _chunk(delta: dict, finish: str | None = None) -> str:
+        return "data: " + _json.dumps({
+            "id": resp_id, "object": "chat.completion.chunk",
+            "created": created, "model": model, "session_id": session_id,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+        }) + "\n\n"
+
+    async def _gen():
+        full_text = ""
+        t0 = time.monotonic()
+        yield _chunk({"role": "assistant"})
+        try:
+            cached = (_cache.get(user_content, session_id=session_id)
+                      if settings.cache.enabled and user_content else None)
+            if cached:
+                full_text = cached.response
+                yield _chunk({"content": full_text})
+            else:
+                async for piece in provider.chat_stream(
+                    messages=messages, model=model,
+                    max_tokens=req.max_tokens or 4096,
+                    **_sampling_kwargs(req),
+                ):
+                    full_text += piece
+                    yield _chunk({"content": piece})
+        except ProviderError as e:
+            # Mid-stream failure: SSE can't change the status code anymore —
+            # emit an explicit error event instead of silently truncating.
+            yield "data: " + _json.dumps({"error": {"message": str(e), "type": "provider_error"}}) + "\n\n"
+        yield _chunk({}, finish="stop")
+        yield "data: [DONE]\n\n"
+
+        # Post-stream bookkeeping
+        latency_ms = (time.monotonic() - t0) * 1000
+        output_tokens = count_tokens(full_text, model)
+        input_tokens = count_messages_tokens(messages, model)
+        if settings.cache.enabled and user_content and full_text:
+            _cache.set(user_content, full_text, input_tokens=input_tokens,
+                       output_tokens=output_tokens, session_id=session_id)
+        _analytics.record(
+            session_id=session_id, provider=settings.provider, model=model,
+            input_tokens_original=orig_input_tokens,
+            input_tokens_sent=input_tokens, output_tokens=output_tokens,
+            tokens_saved=sum(savings.values()), latency_ms=latency_ms,
+            cache_hit=False, layer_savings=savings,
+        )
+
+    return StreamingResponse(_gen(), media_type="text/event-stream",
+                             headers={"Cache-Control": "no-cache",
+                                      "X-Accel-Buffering": "no"})
 
 
 @app.post("/v1/chat/completions", dependencies=[Depends(verify_api_key), Depends(injection_guard)])
@@ -661,6 +727,13 @@ async def chat_completions(req: ChatRequest, request: Request):
         messages, checkpoint_status = await _update_graph(
             session_id, graph, raw_messages, messages, model, savings, user_query
         )
+
+    # Streaming: true SSE passthrough (v0.3). Output-trimming is skipped in
+    # stream mode (can't trim tokens that already left the building) — all
+    # input-side layers (file intel, compression, graph context) still apply.
+    if req.stream:
+        return _stream_response(req, messages, model, user_content,
+                                session_id, savings, orig_input_tokens)
 
     # Layer 5: call provider (or return cache hit)
     response_text, input_tokens_actual, output_tokens, latency_ms = await _call_provider(

--- a/tokenmizer/providers/providers.py
+++ b/tokenmizer/providers/providers.py
@@ -107,6 +107,21 @@ class BaseProvider(ABC):
 
         raise ProviderError(self.__class__.__name__, "max_retries", "All retry attempts exhausted", retryable=False)
 
+    def chat_stream(self, messages: list[dict], model: str = "",
+                    max_tokens: int = 4096, system: str = "", **kwargs):
+        """Async generator yielding text chunks as the provider produces them.
+
+        Providers that support true streaming override this. The base
+        implementation raises so the API layer can return a clear 501 for
+        providers where passthrough streaming isn't implemented yet, instead
+        of silently degrading to a fake (buffered) stream.
+        """
+        raise ProviderError(
+            self.__class__.__name__, "stream_not_supported",
+            f"Streaming passthrough not implemented for {self.__class__.__name__}",
+            retryable=False,
+        )
+
 
 # ── Anthropic ─────────────────────────────────────────────────────────────────
 
@@ -179,6 +194,37 @@ class AnthropicProvider(BaseProvider):
             retryable = e.status_code in (500, 502, 503, 529)
             raise ProviderError("anthropic", f"http_{e.status_code}", str(e), retryable=retryable)
 
+    async def chat_stream(self, messages: list[dict], model: str = "",
+                          max_tokens: int = 4096, system: str = "", **kwargs):
+        """True SSE passthrough — yields text chunks as Anthropic streams them."""
+        try:
+            import anthropic
+        except ImportError:
+            raise ImportError("pip install anthropic")
+        model = model or self.default_model
+        client = anthropic.AsyncAnthropic(api_key=self.api_key)
+
+        sys_parts = [m["content"] for m in messages if m.get("role") == "system"]
+        if system:
+            sys_parts.insert(0, system)
+        conv = [m for m in messages if m.get("role") != "system"]
+        kwargs_clean = _sampling(kwargs)
+        if "stop" in kwargs_clean:
+            kwargs_clean["stop_sequences"] = _as_stop_list(kwargs_clean.pop("stop"))
+        if sys_parts:
+            kwargs_clean["system"] = "\n\n".join(sys_parts)
+
+        try:
+            async with client.messages.stream(
+                model=model, messages=conv, max_tokens=max_tokens, **kwargs_clean
+            ) as s:
+                async for chunk in s.text_stream:
+                    yield chunk
+        except anthropic.RateLimitError as e:
+            raise ProviderError("anthropic", "rate_limit", str(e), retryable=True)
+        except anthropic.APIStatusError as e:
+            raise ProviderError("anthropic", f"http_{e.status_code}", str(e), retryable=False)
+
 
 # ── OpenAI ────────────────────────────────────────────────────────────────────
 
@@ -236,6 +282,37 @@ class OpenAIProvider(BaseProvider):
             err = str(e).lower()
             retryable = "rate" in err or "server" in err or "timeout" in err
             raise ProviderError("openai", "api_error", str(e), retryable=retryable)
+
+    async def chat_stream(self, messages: list[dict], model: str = "",
+                          max_tokens: int = 4096, system: str = "", **kwargs):
+        """True SSE passthrough for OpenAI and all OpenAI-compatible providers
+        (DeepSeek, Mistral, OpenRouter, Grok inherit this)."""
+        try:
+            from openai import AsyncOpenAI
+        except ImportError:
+            raise ImportError("pip install openai")
+        model = model or self.default_model
+        client = AsyncOpenAI(
+            api_key=self.api_key,
+            **({"base_url": self._base_url} if self._base_url else {}),
+        )
+        all_messages = messages[:]
+        if system:
+            all_messages = [{"role": "system", "content": system}] + all_messages
+        try:
+            stream = await client.chat.completions.create(
+                model=model, messages=all_messages, max_tokens=max_tokens,
+                stream=True, **_sampling(kwargs),
+            )
+            async for chunk in stream:
+                delta = chunk.choices[0].delta.content if chunk.choices else None
+                if delta:
+                    yield delta
+        except Exception as e:
+            err = str(e).lower()
+            retryable = "rate" in err or "server" in err or "timeout" in err
+            raise ProviderError(self.__class__.__name__.lower().replace("provider", ""),
+                                "api_error", str(e), retryable=retryable)
 
 
 # ── DeepSeek ──────────────────────────────────────────────────────────────────
@@ -426,6 +503,37 @@ class OllamaProvider(BaseProvider):
                 )
             except Exception as e:
                 raise ProviderError("ollama", "api_error", str(e), retryable=True)
+
+    async def chat_stream(self, messages: list[dict], model: str = "",
+                          max_tokens: int = 4096, system: str = "", **kwargs):
+        """Streaming passthrough for local Ollama models."""
+        import json as _json
+
+        import httpx
+        model = model or self.default_model
+        all_messages = messages[:]
+        if system:
+            all_messages = [{"role": "system", "content": system}] + all_messages
+        payload = {"model": model, "messages": all_messages, "stream": True,
+                   "options": {"num_predict": max_tokens}}
+        try:
+            async with httpx.AsyncClient(timeout=120) as client:
+                async with client.stream("POST", f"{self._base_url}/api/chat",
+                                         json=payload) as r:
+                    r.raise_for_status()
+                    async for line in r.aiter_lines():
+                        if not line.strip():
+                            continue
+                        data = _json.loads(line)
+                        chunk = data.get("message", {}).get("content", "")
+                        if chunk:
+                            yield chunk
+                        if data.get("done"):
+                            break
+        except ProviderError:
+            raise
+        except Exception as e:
+            raise ProviderError("ollama", "api_error", str(e), retryable=True)
 
 
 # ── Registry ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
stream:true now returns real OpenAI chat.completion.chunk SSE for
Anthropic, OpenAI(+compatible: DeepSeek/Mistral/OpenRouter/Grok) and
Ollama. Input-side layers still apply; output trim skipped in stream
mode; cache hits stream as one chunk; post-stream analytics + cache
writes preserved. Unsupported providers get explicit 501, never a fake
buffered stream. Mid-stream provider errors emit an SSE error event.
2 new e2e tests (219 total).
