### PR TITLE
v0.3.2: full-repo audit — fix broken LLM extraction, harden MCP server, redesign graph viz

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenmizer",
-  "version": "0.2.3",
+  "version": "0.3.2",
   "description": "Never lose your AI context again. Graph-backed memory, session checkpointing, and file intelligence for Claude Code and any LLM.",
   "author": {
     "name": "Shweta Mishra",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,22 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Windows is in the matrix because the 2026-07-10 audit found THREE
+    # Windows-only bugs Linux CI could never catch: a cp1252
+    # UnicodeEncodeError crashing `tokenmizer --help`, a leaked SQLite
+    # handle blocking corrupt-DB recovery (WinError 32), and console
+    # encoding issues in scripts. One Windows leg (latest Python only —
+    # Windows runners are slow) keeps that whole bug class from ever
+    # shipping again.
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12"]
+        include:
+          - os: windows-latest
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v4
@@ -20,14 +32,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: pip
 
       - name: Install dependencies
         run: |
@@ -40,16 +45,21 @@ jobs:
       # Coverage threshold lives in pyproject.toml [tool.coverage.report]
       # fail_under — single source of truth, do NOT override it here.
       - name: Run tests with coverage
-        run: |
-          pytest tests/ \
-            --cov=tokenmizer \
-            --cov-report=term-missing \
-            --cov-report=xml \
-            -v
+        run: pytest tests/ --cov=tokenmizer --cov-report=term-missing --cov-report=xml -v
+
+      # Regression guard for the cp1252 crash: --help must work on a
+      # non-UTF-8 Windows console, not just under pytest's captured IO.
+      - name: CLI smoke test (Windows encoding regression)
+        if: runner.os == 'Windows'
+        run: python -m tokenmizer.cli --help
+
+      - name: MCP stdio e2e
+        if: matrix.python-version == '3.12'
+        run: python scripts/mcp_e2e_check.py
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.12' && runner.os == 'Linux'
         with:
           file: ./coverage.xml
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,20 @@ jobs:
         with:
           python-version: "3.12"
 
+      # The release tag (v0.3.2) must match the package version — otherwise
+      # a stale tag publishes the wrong code under the wrong number. Version
+      # pins across server.json / plugin.json / app.py are enforced by
+      # tests/unit/test_version_consistency.py in the test run below.
+      - name: Verify tag matches package version
+        run: |
+          pip install -e .
+          PKG_VERSION=$(python -c "import tokenmizer; print(tokenmizer.__version__)")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match package version $PKG_VERSION"
+            exit 1
+          fi
+
       - name: Run tests first — never publish a broken build
         run: |
           pip install -e ".[dev]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,160 @@
 # Changelog
 
+## [0.3.2] — 2026-07-10 — full-repo audit: graph memory, MCP server, visualization
+
+### Critical — the LLM extraction path never worked
+- **`api/app.py`:** the background extraction called
+  `HybridExtractor(provider_fn=_pfn)` — a kwarg `__init__` never accepted —
+  so it raised `TypeError` on EVERY call, and even without that,
+  `ext.extract(_msgs)` omitted `provider_fn`, which defaults to `None` and
+  skips the LLM pass. Net effect: **`use_llm_extraction: true` has never
+  once produced an LLM extraction** — every call raised, was caught by the
+  broad except, and logged as if it were a transient provider failure.
+  Fixed (`HybridExtractor()` + `extract(_msgs, provider_fn=_pfn)`) with a
+  regression test that replicates the exact call pattern.
+
+### Graph memory — topic classifier
+- **"Go" the verb collided with Go the language:** "Go with tRPC for the
+  API layer" classified as `language` (first-single-word-hit-wins never
+  reached "trpc"), so a later "use gRPC instead" never superseded it.
+  Bare "go" removed from language keywords; unambiguous forms kept
+  ("golang", "in go", "use go", ...).
+- **Vocabulary drift:** hybrid_extractor.py knew supabase/clerk/etc., the
+  classifier didn't — those decisions classified as None and supersession
+  silently never fired. New buckets: backend_platform, auth_provider,
+  payments, observability, state_management, package_manager, styling.
+- **Multi-topic decisions collapsed to one topic:** "Use FastAPI with
+  SQLAlchemy and PostgreSQL" returned only `web_framework`; a later
+  Postgres→SQLite switch was never detected as contradicting it. New
+  `classify_topics()` returns ALL matched topics; contradiction detection
+  is now set-intersection. Bigrams match first and consume their words
+  ("session store" no longer leaks a spurious `auth_mechanism`).
+  `classify_topic()` kept as a backward-compatible wrapper.
+- **`ARCHIVED` was unreachable:** documented, fully wired into decay/
+  prune/query logic — and nothing ever set it. The README advertised a
+  4-state model whose 4th state could not occur. SUPERSEDED decisions now
+  age into ARCHIVED after 7 days (from supersession time, not creation).
+- `/api/decision/invalidate` substring-matched across ALL decision nodes
+  regardless of status — a short label could flip already-SUPERSEDED
+  history nodes to INVALIDATED, destroying their supersession record.
+  Now only ACTIVE decisions are eligible, and the response lists exactly
+  which nodes were affected.
+
+### MCP server — hardened like a client integration
+- **`isError` was string-sniffing** (`result_text.startswith("❌")`): a
+  missing required argument produced `"Tool error: 'session_id'"` with
+  `isError: false` — MCP clients saw a *successful* result. Handlers now
+  return `(text, is_error)` structurally; missing/invalid args produce
+  typed validation errors with `isError: true`.
+- **Three server-killer inputs fixed:** an exception inside `initialize`
+  crashed the whole stdio loop with no JSON-RPC error (client hung, then
+  watched the subprocess die); a valid-JSON-but-not-an-object line
+  (`[1,2]`) raised AttributeError and killed the loop; malformed JSON was
+  silently dropped (`continue` — the request hung forever, no log, no
+  error). Per-request try/except now returns `-32603`, non-objects get
+  `-32600`, parse failures get `-32700` + a warning log.
+- **`logger` was dead code** — defined, never called once. Every caught
+  exception was invisible to the operator. `run_stdio_server()` now
+  configures stderr logging (stdout stays protocol-only), controlled by
+  `TOKENMIZER_MCP_LOG_LEVEL`.
+- Input validation: `session_id`/`file_path` presence+type, `level` enum,
+  `token_budget` positive-int (bool explicitly rejected — it's an int
+  subclass), non-dict `arguments`.
+- 18 new unit tests (`tests/unit/test_mcp_server.py`) covering all of the
+  above; `scripts/mcp_e2e_check.py` still ALL PASS.
+- `server.json` version synced (was 0.2.6, three releases stale).
+
+### Silent failures made visible (continuing the v0.2.x hardening)
+- `hybrid_extractor.llm_extract`: debug→warning (a provider outage
+  silently degraded every turn to heuristic-only).
+- `compression/engine.filter_json`: swallowed ALL exceptions with zero
+  logging (returned unfiltered content). Real failures now log at
+  warning; the benign not-JSON case stays quiet.
+- `graph._load_transitions`: DB corruption looked identical to the benign
+  first-run case (both debug). Corruption now warns; first-run stays debug.
+- `file_intelligence.detect_file_type`: sniff failure silently reclassified
+  files as "text" (worse extraction, no signal) — now warns. PDFs where
+  NO page yields text now warn once (scanned/image-only detection).
+- `CheckpointManager`: new `persistence_broken` flag — previously the
+  constructor swallowed a triple init failure and reported healthy while
+  every subsequent save was doomed. `get_latest()` now raises
+  `StorageError` on DB read failure instead of returning None ("no
+  checkpoint found, 404" vs "your checkpoints exist but are unreadable"
+  are different problems; callers can finally tell them apart).
+- **`_db_connect` leaked the connection when the WAL PRAGMA failed on a
+  corrupt DB file** (both graph.py and manager.py) — on Windows the open
+  handle blocked the documented delete-and-recreate recovery path
+  (WinError 32). Found because the chaos test failed for the RIGHT reason
+  once get_latest stopped swallowing errors.
+
+### Security — redaction gaps
+- URL-embedded credentials (`postgres://admin:pass@host/db`) matched NO
+  pattern — no `password=` literal, no recognized prefix. Now redacted
+  (credential part only; host survives for readability).
+- Added OpenRouter / Hugging Face / xAI / Together key patterns.
+- Checkpoint `next_action` (a raw 200-char message slice persisted to
+  SQLite) is now independently redacted — defense-in-depth so the
+  single-point-of-application assumption in chat_completions() is not the
+  only thing between a pasted key and the checkpoint DB.
+
+### Visualization — redesigned (was a generic node soup)
+- The old shareable HTML exported `transitions` (the supersession
+  history — the one thing this product tracks that a generic graph view
+  doesn't) and then never rendered them. It also loaded D3 from a CDN, so
+  the "self-contained" artifact broke offline.
+- New artifact (zero external deps, hand-rolled force layout):
+  supersession arcs (dashed red, old→new, arrowheads), a clickable
+  "Decision history" timeline panel (struck-through old label → new label
+  with trigger/reason/timestamp; click = spotlight both nodes + center),
+  glow rings on active decisions vs dashed rings + strikethrough on
+  superseded/archived, red rings on invalidated, per-type filter chips,
+  "Active only" toggle, text search, wheel-zoom/pan, one-click PNG export.
+- Verified in a real browser (not just unit-tested): filters, search,
+  timeline spotlight, and layout all exercised via DOM inspection.
+
+### CLI
+- `tokenmizer --help` crashed on Windows (cp1252) with UnicodeEncodeError
+  from the 🧠 emoji — found by dry-running the README quick start. Same
+  UTF-8 reconfigure fix the benchmark runners got in v0.2.4; the CLI had
+  been missed.
+
+### Round 2 — extraction-quality residuals (same audit, follow-up pass)
+- **Near-duplicate decision nodes merged instead of self-superseding:**
+  one message ("Decided: use React for the frontend.") could emit two
+  decision variants ("Use React" + "use React for the frontend.") via
+  different regex passes; they became two nodes and one superseded the
+  other — a bogus "Changed:" line in every resume. `_is_same_decision`
+  now recognizes containment (smaller label's words ⊆ larger's, min 2
+  words so "Use PostgreSQL" is NOT collapsed into "Switch from PostgreSQL
+  to SQLite"), and `add_node` fuzzy-merges same-decision variants: keeps
+  the existing node, upgrades to the longer label, backfills the summary,
+  never resurrects SUPERSEDED status. Verified end-to-end: the demo
+  scenario now produces exactly one transition (React→Next.js) and a
+  clean resume block.
+- **Validator now honors extractor corroboration confidence:** it used to
+  recompute confidence purely from label length/wording, so a doubly-
+  corroborated short decision (0.95) could be rejected while a verbose
+  weakly-sourced one passed. `validate()` gains `extractor_confidence`;
+  final = max(heuristic, (heuristic+extractor)/2) — monotone (evidence
+  only raises), not an override (heuristic-only 0.65 still fails a 0.65
+  threshold), and hard rejects remain absolute (0.95 cannot resurrect
+  junk). Wired from `add_node` via the existing confidence≠0.7 sentinel.
+- **`HybridExtractor.min_confidence` is no longer dead code:** extract()
+  now filters merged output by merge()'s confidence tiers — default 0.55
+  keeps every tier (behavior unchanged); 0.7 drops heuristic-only items;
+  0.9 keeps only corroborated ones. Decisions filter per-item, simple
+  lists per-category.
+- Test fixture fix: `test_prune_preserves_decisions` used ten decisions
+  differing only by a trailing digit — 83% word-overlap, which
+  `_is_same_decision` always considered the same decision; the merge fix
+  made that judgment consequential, collapsing the fixture. Replaced with
+  ten genuinely distinct decisions across different topic buckets.
+
+### Tests
+- 220 → 275 (55 new: MCP server 18, classifier+dedup 18, archival 3,
+  invalidate-scope 2, redaction 5, LLM-pass regression 1, validator
+  blending 4, min_confidence filter 4).
+
 ## [0.3.1] — 2026-07-03 — shareable graph visualization
 
 - NEW `GET /api/graph/{session_id}/html` — self-contained dark interactive
@@ -111,7 +266,9 @@
   removed; benchmark table updated to freshly measured v0.2.4 numbers with
   date and sample-size caveat.
 
-## [Unreleased] — tokenizer, cache, and version consistency fixes
+## Shipped in [0.2.4] — tokenizer, cache, and version consistency fixes
+
+(Header fixed 2026-07-10: this section was left titled "[Unreleased]" after it shipped.)
 
 ### Correctness — core value proposition
 - **`core/tokenizer.py`:** Claude/Anthropic models were counted with tiktoken
@@ -175,7 +332,9 @@
   Quick Start code example (previously only mentioned deep in the CLI
   section) — Cursor/Continue.dev users were hitting an unexplained HTTP 501.
 
-## [Unreleased] — security/correctness audit pass
+## Shipped in [0.2.4] — security/correctness audit pass
+
+(Header fixed 2026-07-10: this section was left titled "[Unreleased]" after it shipped.)
 
 Full senior-level audit covering security, silent failures, dead code,
 and benchmark honesty. See `TESTING.md` for what's verified vs. not, and

--- a/README.md
+++ b/README.md
@@ -76,9 +76,15 @@ Your App  →  TokenMizer (:8000)  →  Claude / GPT / Gemini / any LLM
 | 🟢 `ACTIVE` | Current — in effect | ✅ Always |
 | 🟡 `SUPERSEDED` | Replaced by newer decision | ⚠️ 7 days |
 | 🔴 `INVALIDATED` | Explicitly wrong/cancelled | ⚠️ Always (warning) |
-| ⬜ `ARCHIVED` | Old but valid, not relevant | ❌ Never |
+| ⬜ `ARCHIVED` | Superseded >7 days ago — aged out | ❌ Never |
 
 History is **never deleted**. "Why did we switch from React to Next.js?" — always answerable.
+
+> Honesty note (2026-07-10 audit): before v0.3.2, `ARCHIVED` was advertised
+> here but **unreachable** — the decay/prune/query logic all handled it, yet
+> no code path ever set it. Superseded decisions now age into `ARCHIVED`
+> automatically after 7 days (`GraphMemory.ARCHIVE_SUPERSEDED_AFTER_DAYS`),
+> which is what makes the "⚠️ 7 days" row above actually true.
 
 ---
 
@@ -379,7 +385,13 @@ default_model: claude-sonnet-4-6
 graph_checkpoint:
   enabled: true
   trigger_at_percent: 0.85
-  use_llm_extraction: false     # true = 80%+ recall, needs key (~$0.001/turn)
+  use_llm_extraction: false     # true = hybrid LLM+heuristic extraction
+                                # (needs a provider key, ~$0.001/turn).
+                                # NOTE: before v0.3.2 this flag silently did
+                                # nothing — the call site passed provider_fn
+                                # to the wrong function and raised TypeError
+                                # on every turn, falling back to heuristics.
+                                # Fixed + regression-tested; see CHANGELOG.
 
 compression:
   enabled: true
@@ -419,7 +431,7 @@ TOKENMIZER_API_KEY=strong-key docker-compose up
 | `/api/checkpoint` | POST | Manual checkpoint |
 | `/api/decision/invalidate` | POST | Mark decision as invalid |
 | `/api/graph/{id}` | GET | Session graph stats |
-| `/api/graph/{id}/html` | GET | **Interactive graph page** — open, drag, zoom, share |
+| `/api/graph/{id}/html` | GET | **Interactive graph page** — decision-history timeline, supersession arcs, type/status filters, search, zoom/pan, PNG export. Zero external dependencies (works offline) |
 | `/api/stats` | GET | Token savings analytics |
 | `/health` | GET | Health check |
 | `/docs` | GET | Swagger UI |
@@ -432,7 +444,13 @@ TOKENMIZER_API_KEY=strong-key docker-compose up
 - Secret/PII redaction applied once at ingestion, before graph storage,
   checkpoint storage, AND every LLM call (main chat *and* the background
   extraction model — these are separate, the redaction gap between them
-  was a real bug, now fixed)
+  was a real bug, now fixed). Patterns cover Anthropic/OpenAI/Google/
+  GitHub/AWS/Slack/Stripe/JWT/OpenRouter/HF/xAI keys, URL-embedded
+  credentials (`postgres://user:pass@host` — a 2026-07 audit gap, fixed),
+  and generic `key=`/`password=` assignments. Best-effort by nature —
+  an unrecognized format with no keyword context can still slip through.
+  The checkpoint layer independently re-redacts what it persists
+  (defense-in-depth, added in the same audit).
 - Session-isolated cache (sensitive data never shared across sessions)
 - Basic prompt-injection keyword filter — catches copy-pasted jailbreak
   templates only; **not** a security boundary against a motivated
@@ -566,7 +584,7 @@ Contributions welcome — this project merges fast (median PR review < 1 day).
 git clone https://github.com/Shweta-Mishra-ai/tokenmizer
 cd tokenmizer
 pip install -e ".[dev]"
-pytest tests/ -v && ruff check tokenmizer/     # 218 tests, must stay green
+pytest tests/ -v && ruff check tokenmizer/     # 262 tests, must stay green
 python scripts/mcp_e2e_check.py                # full-pipeline e2e check
 ```
 

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,0 +1,142 @@
+# TokenMizer Demo Script / Storyboard
+
+Target length: **2.5–3 minutes.** Four acts: checkpoint → resume → graph
+visualization → live MCP tool calls from Claude Code. Every command below
+was dry-run on 2026-07-10 against this exact codebase — nothing here is
+aspirational.
+
+## Prep (before recording — not in the video)
+
+```powershell
+# 1. Clean slate: delete old state so the demo graph is exactly what you build
+Remove-Item -Recurse -Force .\checkpoints -ErrorAction SilentlyContinue
+
+# 2. Two terminals side by side. Left = server, right = your commands.
+#    Font size 16+, dark theme. Browser window ready on a second half of screen.
+
+# 3. Left terminal — start the proxy and LEAVE IT VISIBLE (its log lines
+#    during checkpoint are part of the show):
+tokenmizer serve
+```
+
+Optional but recommended: set a real provider key so Act 1 can use live
+chat; if you don't want live LLM calls in the demo, the curl-based variant
+in Act 1 works with no key at all.
+
+## Act 1 — Build up a session worth saving (~45s)
+
+**Say:** "I've been working on an auth service all afternoon. My AI session
+knows every decision I made — and it's about to hit the context limit."
+
+Right terminal — feed the session through the proxy (paste one by one so
+the server log visibly reacts; each is one `curl`):
+
+```bash
+SID=demo-auth-service
+
+curl -s -X POST http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"messages\":[{\"role\":\"user\",\"content\":\"Goal: build a FastAPI auth service with JWT and PostgreSQL\"}],\"session_id\":\"$SID\",\"model\":\"claude-sonnet-4-6\"}" > /dev/null
+
+curl -s -X POST http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"messages\":[{\"role\":\"user\",\"content\":\"Decided: use bcrypt for password hashing. Completed the login endpoint in api/auth.py, 18 tests passing.\"}],\"session_id\":\"$SID\",\"model\":\"claude-sonnet-4-6\"}" > /dev/null
+
+curl -s -X POST http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"messages\":[{\"role\":\"user\",\"content\":\"Decided: use React for the frontend.\"}],\"session_id\":\"$SID\",\"model\":\"claude-sonnet-4-6\"}" > /dev/null
+
+# THE MONEY LINE — a decision gets REVERSED. Say it out loud as you paste:
+curl -s -X POST http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"messages\":[{\"role\":\"user\",\"content\":\"Actually, switch from React to Next.js for the frontend. Better SEO, benchmarked LCP 40 percent faster.\"}],\"session_id\":\"$SID\",\"model\":\"claude-sonnet-4-6\"}" > /dev/null
+```
+
+**Say:** "That last message reversed an earlier decision. Watch what
+TokenMizer does with that."
+
+> No API key? Add `"provider": "ollama"` config, or skip the provider
+> entirely — extraction happens on the request side, so even failed
+> upstream calls still build the graph. Verify with:
+> `curl -s http://localhost:8000/api/graph/demo-auth-service | python -m json.tool`
+
+## Act 2 — Checkpoint + resume (~40s)
+
+```bash
+tokenmizer checkpoint demo-auth-service
+```
+
+**Camera focus:** the green panel — checkpoint ID, node count, and the
+resume context. **Say:** "My whole afternoon, checkpointed."
+
+Now the punchline. **Say:** "Next morning. New session. Instead of
+re-explaining the project for ten minutes:"
+
+```bash
+tokenmizer resume demo-auth-service
+```
+
+**Camera focus:** the resume block, especially the token count in the
+title and the `Changed: React → Next.js` line. **Say:** "~250 tokens.
+Notice it doesn't just remember the decisions — it remembers that Next.js
+*replaced* React, so the model can't get confused by the stale choice."
+
+## Act 3 — The graph (~40s)
+
+Open in the browser:
+
+```
+http://localhost:8000/api/graph/demo-auth-service/html
+```
+
+Choreography (in this order — it's a story, not a tour):
+
+1. Let the force layout settle (~2s). Nodes glow by type; the legend chips
+   are bottom-left.
+2. **Point at the dashed red arc** between the React and Next.js nodes.
+   Say: "That's a supersession — the graph knows WHY this edge exists."
+3. **Click the entry in the Decision history panel** (right side): the
+   old decision is struck through, the new one bold, the reason under it.
+   Clicking spotlights both nodes and dims everything else. Say: "Every
+   reversal in the session, with trigger and evidence, one click away."
+4. Press Escape to reset, click **"Active only"** — the superseded React
+   node vanishes. Say: "Current truth only."
+5. Type "bcrypt" in the search box — one node stays lit.
+6. Click **⬇ PNG** — a shareable image downloads. Say: "And it's one file,
+   no CDN, works offline — this page IS the export."
+
+## Act 4 — Live MCP from Claude Code (~45s)
+
+Prereq: `.mcp.json` in the project you open with Claude Code (this repo
+ships one):
+
+```json
+{
+  "mcpServers": {
+    "tokenmizer": {
+      "command": "python3",
+      "args": ["-m", "tokenmizer.mcp.server"],
+      "env": { "TOKENMIZER_URL": "http://localhost:8000" }
+    }
+  }
+}
+```
+
+1. Open Claude Code in the repo. Type: **"Resume my tokenmizer session
+   demo-auth-service"** — Claude calls the `resume_session` MCP tool; the
+   tool result shows the same ~250-token context. Say: "Same memory, now
+   inside my coding agent."
+2. Type: **"What's in the knowledge graph for demo-auth-service?"** —
+   Claude calls `get_graph_stats`; node/status breakdown appears.
+3. (Optional, if time) **"Analyze data/sales.csv with tokenmizer"** —
+   `analyze_file` returns schema + sample in a few hundred tokens.
+   Prepare any CSV beforehand.
+4. Close: split-screen the graph page + Claude Code. Say: "Checkpoint,
+   resume, see the reasoning, use it from any MCP client. pip install
+   tokenmizer."
+
+## Failure modes to avoid on camera
+
+- **Don't reuse a session id from prior takes** — old state reloads from
+  SQLite and the graph shows stale nodes. Delete `./checkpoints` between
+  takes (prep step 1).
+- The resume panel says "graph was empty" if you checkpoint before Act 1's
+  messages — order matters.
+- If port 8000 is taken: `tokenmizer serve --port 8001` and adjust every
+  URL (including `.mcp.json`'s `TOKENMIZER_URL`).
+- Claude Code caches MCP server processes — restart it if you restarted
+  the proxy, or the first tool call may hit a dead connection.
+- On Windows, run the curls in Git Bash (as written) or convert to
+  `Invoke-RestMethod` — cmd.exe quoting will mangle the JSON.

--- a/docs/superpowers/plans/2026-07-10-audit-fixes.md
+++ b/docs/superpowers/plans/2026-07-10-audit-fixes.md
@@ -1,0 +1,90 @@
+# Audit Fixes Implementation Plan (2026-07-10)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all confirmed bugs from the 2026-07-10 three-track audit (graph memory, MCP server, silent failures), redesign the graph visualization, then truth-pass the README and write a demo storyboard.
+
+**Architecture:** Localized fixes to existing modules; no restructuring. Classifier stays deterministic (heuristics only, per owner decision). Visualization becomes a self-contained no-CDN HTML artifact rendering supersession history as a first-class element.
+
+**Tech Stack:** Python 3.10+, pytest, D3 (inlined), stdlib only for new code.
+
+## Global Constraints
+
+- All 218 existing tests must stay green (`pytest tests/ -v` in `.venv`).
+- `ruff check tokenmizer/` must pass (CI-blocking).
+- No new required dependencies.
+- Version stays 0.3.1 until release; `server.json` synced to it.
+- Every bug fix gets a regression test that fails before the fix.
+
+---
+
+### Task 1: Fix LLM extraction call site (app.py)
+
+**Files:** Modify `tokenmizer/api/app.py:423-424`; Test `tests/unit/test_hybrid_extractor.py`
+
+- [ ] Test: construct the exact call pattern app.py uses (`HybridExtractor()` + `extract(msgs, provider_fn=fn)` with a stub async fn) and assert LLM results appear in output.
+- [ ] Fix: `ext = HybridExtractor()` then `extracted = await ext.extract(_msgs, provider_fn=_pfn)`.
+- [ ] Add a signature-compat assertion test importing the app module's background path (guards against future drift).
+
+### Task 2: MCP server hardening (server.py)
+
+**Files:** Modify `tokenmizer/mcp/server.py`; Test new `tests/unit/test_mcp_server.py`
+
+- [ ] Handlers return `(text, is_error)` tuples (or raise a typed `ToolInputError`); `tools/call` sets `isError` structurally, never via `startswith("❌")`.
+- [ ] Validate required args (`session_id`, `file_path`) with clear messages; validate `arguments` is a dict; validate `token_budget` is int.
+- [ ] Wrap per-request dispatch in try/except → JSON-RPC error `-32603`, keep loop alive. Guard non-dict `req`. Log dropped malformed JSON at warning.
+- [ ] `logging.basicConfig(stream=sys.stderr)` in `run_stdio_server()`; log every tool error at warning.
+- [ ] Unknown tool → isError true.
+- [ ] Sync `server.json` version to 0.3.1.
+- [ ] Tests: missing arg → isError true; `[1,2]` request line → server survives; unknown tool → isError; malformed JSON → loop continues; initialize failure → error response not crash.
+
+### Task 3: Topic classifier fixes (decision_tracker.py)
+
+**Files:** Modify `tokenmizer/graph_memory/decision_tracker.py`; Test `tests/unit/test_validator.py` or new `test_decision_tracker.py`
+
+- [ ] `classify_topics()` (new, plural) returns a **set** of all matched topics; `classify_topic()` kept as thin wrapper (first of set, stable order) for compat.
+- [ ] Fix "Go" collision: "go" only counts as language keyword when followed/preceded by language context (e.g. not when followed by "with"/"for" as imperative); simplest robust rule: drop bare "go" from single-word keywords, keep bigrams ("golang", "go lang", "in go", "go backend").
+- [ ] Vocabulary: merge tech names from hybrid_extractor.py `_DECISION_FOR` (supabase, clerk, firebase, etc.); add auth providers (clerk, auth0, firebase auth), BaaS (supabase, firebase, appwrite), API (trpc already present — ensure reachable).
+- [ ] `find_contradicting_decisions`: compare topic **sets** — contradiction if intersection non-empty.
+- [ ] Tests: each audit example ("Go with tRPC" → api_style not language; "Use Supabase..." → backend topic; FastAPI+SQLAlchemy+Postgres → 3 topics; Postgres→SQLite supersedes the multi-topic node).
+
+### Task 4: Silent-failure logging fixes
+
+**Files:** `hybrid_extractor.py:318` (debug→warning), `compression/engine.py:334` (add warning log), `graph.py:215` (warn unless "no such table"), `filters/file_intelligence.py:99,540` (debug→warning for total failure; keep per-page at debug but warn if ALL pages empty)
+
+- [ ] Each with a test asserting the log record is emitted (caplog).
+
+### Task 5: ARCHIVED reachability + invalidate scope
+
+**Files:** `tokenmizer/graph_memory/graph.py` (prune/decay path), `tokenmizer/api/app.py` (invalidate endpoint)
+
+- [ ] In `apply_importance_decay` or `prune()`: SUPERSEDED decisions older than N days (default 7, config-able) → ARCHIVED. Matches README's "superseded shown 7 days" claim.
+- [ ] `invalidate_decision`: only match COMPLETED (active) decisions by default; return list of affected node ids; document multi-match behavior.
+- [ ] Tests: supersede → age past threshold → decay run → ARCHIVED; invalidate no longer flips SUPERSEDED nodes.
+
+### Task 6: Redaction + checkpoint robustness
+
+**Files:** `tokenmizer/security/redaction.py`, `tokenmizer/checkpoints/manager.py`
+
+- [ ] Add patterns: URL-embedded credentials (`scheme://user:pass@host`), Cohere/Mistral/Together/Azure key formats (documented best-effort), generic high-entropy `Bearer` tokens.
+- [ ] `CheckpointManager.create()`: redact `next_action` snippet before persist (defense-in-depth, cheap).
+- [ ] `_safe_init_db`: set `self.persistence_broken = True` on total failure; surface via stats.
+- [ ] `get_latest()`: distinguish empty vs error (return sentinel/raise on DB error).
+- [ ] Tests for each: connection-string redacted; broken dir → flag set; corrupt DB → error distinct from empty.
+
+### Task 7: Visualization redesign
+
+**Files:** Rewrite `tokenmizer/graph_memory/visualization.py` (`to_share_html`), keep `to_vis_json`/`to_obsidian_canvas` API stable
+
+- [ ] Inline d3 (vendored minified or hand-rolled force layout — decide by size; no CDN).
+- [ ] Render `transitions`: supersession arcs with reason tooltips; superseded nodes visually chained to successors; "decision timeline" side panel ordered by timestamp.
+- [ ] Filter chips by node type + status; text search; active-only toggle.
+- [ ] "Export PNG" button (canvas serialization of the SVG).
+- [ ] Test: generated HTML contains transitions data, no external URLs, valid JSON payloads.
+
+### Task 8: README truth-pass + demo storyboard
+
+**Files:** `README.md`, new `docs/DEMO_SCRIPT.md`
+
+- [ ] Fix 4-state table (ARCHIVED now reachable — describe actual trigger), note LLM extraction fixed, sync claims to code, dry-run quick-start commands in the venv.
+- [ ] Demo storyboard: checkpoint → resume → visualization → live MCP tool calls from Claude Code, with exact commands and expected on-screen results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenmizer"
-version = "0.3.1"
+version = "0.3.2"
 description = "Reduce AI context loss by 2x. Graph-backed checkpoint and resume for any LLM session."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Shweta-Mishra-ai/tokenmizer",
     "source": "github"
   },
-  "version": "0.2.6",
+  "version": "0.3.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "tokenmizer",
-      "version": "0.2.6",
+      "version": "0.3.2",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/tests/integration/test_api_endpoint.py
+++ b/tests/integration/test_api_endpoint.py
@@ -192,7 +192,13 @@ class TestHealthAndDocs:
         assert r.json()["status"] == "ok"
 
     def test_graph_share_html(self, client):
-        """Shareable graph page: real HTML with D3 + the session's nodes."""
+        """Shareable graph page: self-contained interactive HTML.
+
+        REDESIGNED (2026-07-10): no more D3-from-CDN — the artifact must
+        work offline. It must also actually render the supersession
+        history (transitions), which the old template computed and then
+        silently never used.
+        """
         c, _ = client
         # Put something in the graph via the pipeline first
         c.post("/v1/chat/completions", json={
@@ -203,5 +209,67 @@ class TestHealthAndDocs:
         r = c.get("/api/graph/html-viz-test/html")
         assert r.status_code == 200
         assert "text/html" in r.headers["content-type"]
-        assert "d3" in r.text and "forceSimulation" in r.text
         assert "html-viz-test" in r.text
+        # Self-contained: no external script/style loads
+        assert "<script src=" not in r.text
+        assert "https://cdn" not in r.text
+        # Supersession story is first-class now
+        assert "Decision history" in r.text
+        assert '"transitions"' in r.text
+        # Filtering / export controls present
+        assert "Active only" in r.text
+        assert "exportPng" in r.text
+
+
+class TestInvalidateDecisionScope:
+    """
+    AUDIT FIX (2026-07-10): /api/decision/invalidate previously substring-
+    matched across ALL decision nodes regardless of status — invalidating
+    "postgres" would also flip an already-SUPERSEDED postgres decision,
+    destroying its supersession history. Only ACTIVE (COMPLETED) decisions
+    are now eligible, and the response lists exactly what was affected.
+    """
+
+    def _seed_graph(self, session_id, tmp_path):
+        from tokenmizer.api import app as app_module
+        from tokenmizer.graph_memory.graph import GraphMemory, NodeStatus, NodeType
+
+        # Isolated storage dir: using the app's real ./checkpoints dir made
+        # this test order-dependent — state persisted by a previous run
+        # (the INVALIDATED node) reloaded on construction and dedup kept
+        # the higher-ranked status, so no ACTIVE node existed to match.
+        g = GraphMemory(session_id, storage_dir=str(tmp_path))
+        old_id = g.add_node(NodeType.DECISION, "Use PostgreSQL for storage",
+                            NodeStatus.COMPLETED)
+        new_id = g.add_node(NodeType.DECISION, "Switch to PostgreSQL 16 with pgvector",
+                            NodeStatus.COMPLETED)
+        # add_node supersedes the first (same topic); confirm the precondition
+        assert g._nodes[old_id].status == NodeStatus.SUPERSEDED
+        app_module._graph_cache[session_id] = g
+        return g, old_id, new_id
+
+    def test_invalidate_skips_superseded_nodes(self, client, tmp_path):
+        c, _ = client
+        g, old_id, new_id = self._seed_graph("invalidate-scope-test", tmp_path)
+
+        r = c.post("/api/decision/invalidate",
+                   params={"session_id": "invalidate-scope-test",
+                           "decision_label": "postgresql",
+                           "reason": "benchmarks showed it was wrong"})
+        assert r.status_code == 200
+        body = r.json()
+
+        from tokenmizer.graph_memory.graph import NodeStatus
+        # The ACTIVE node flips; the SUPERSEDED one keeps its history.
+        assert g._nodes[new_id].status == NodeStatus.INVALIDATED
+        assert g._nodes[old_id].status == NodeStatus.SUPERSEDED
+        affected_ids = {n["node_id"] for n in body["affected_nodes"]}
+        assert affected_ids == {new_id}
+
+    def test_invalidate_no_active_match_404s(self, client, tmp_path):
+        c, _ = client
+        self._seed_graph("invalidate-404-test", tmp_path)
+        r = c.post("/api/decision/invalidate",
+                   params={"session_id": "invalidate-404-test",
+                           "decision_label": "no-such-decision"})
+        assert r.status_code == 404

--- a/tests/unit/test_decision_tracker.py
+++ b/tests/unit/test_decision_tracker.py
@@ -1,0 +1,174 @@
+"""
+Regression tests for the topic classifier (2026-07-10 audit).
+
+Confirmed misclassifications before the fix (all reproduced by execution):
+  - "Go with tRPC for the API layer"  → "language" (imperative "Go" collided
+    with Go-the-language; first-single-word-hit-wins never reached "trpc")
+  - "Use Supabase for the backend"    → None (vocabulary gap; the sibling
+    hybrid_extractor.py knew "supabase" but this file didn't)
+  - "Use Clerk for authentication"    → None (same gap)
+  - "Use FastAPI with SQLAlchemy and PostgreSQL" → only "web_framework";
+    a later Postgres→SQLite switch was never detected as contradicting it.
+"""
+from tokenmizer.graph_memory.decision_tracker import (
+    classify_topic,
+    classify_topics,
+    find_contradicting_decisions,
+)
+from tokenmizer.graph_memory.graph import GraphMemory, NodeStatus, NodeType
+
+# ── classify_topics: the audit cases ─────────────────────────────────────────
+
+def test_go_verb_does_not_classify_as_language():
+    """'Go with X' is an imperative, not a language choice."""
+    topics = classify_topics("Go with tRPC for the API layer")
+    assert "language" not in topics
+    assert "api_style" in topics
+
+
+def test_go_language_still_detected_with_context():
+    assert "language" in classify_topics("Rewrite the service in Go")
+    assert "language" in classify_topics("Use Golang for the workers")
+
+
+def test_supabase_classified():
+    topics = classify_topics("Use Supabase for the backend")
+    assert topics, "Supabase must classify (vocabulary gap in audit)"
+
+
+def test_clerk_and_auth0_share_a_bucket():
+    t1 = classify_topics("Use Clerk for authentication")
+    t2 = classify_topics("Let's go with Auth0")
+    assert t1 & t2, f"Clerk {t1} and Auth0 {t2} must share a topic bucket"
+
+
+def test_multi_topic_statement_returns_all_topics():
+    topics = classify_topics("Use FastAPI with SQLAlchemy and PostgreSQL for the backend")
+    assert "web_framework" in topics
+    assert "orm" in topics
+    assert "database" in topics
+
+
+def test_bigram_consumes_words_no_false_single_word_topic():
+    """'session store' is a cache_backend bigram; the single word 'session'
+    must NOT additionally contribute auth_mechanism."""
+    topics = classify_topics("Use Redis as the session store")
+    assert "cache_backend" in topics
+    assert "auth_mechanism" not in topics
+
+
+def test_unknown_tech_returns_empty_set():
+    assert classify_topics("Adopt the flurbo protocol for widget sync") == set()
+
+
+def test_classify_topic_backward_compat():
+    """Singular wrapper still returns a str or None."""
+    assert classify_topic("Use PostgreSQL for storage") == "database"
+    assert classify_topic("Adopt the flurbo protocol") is None
+
+
+# ── find_contradicting_decisions: set-intersection semantics ─────────────────
+
+def _graph_with_decision(tmp_path, label, summary=""):
+    g = GraphMemory(session_id="t-classifier", storage_dir=str(tmp_path))
+    node_id = g.add_node(NodeType.DECISION, label, status=NodeStatus.COMPLETED,
+                         summary=summary)
+    return g, node_id
+
+
+def test_db_switch_supersedes_multi_topic_decision(tmp_path):
+    """THE audit scenario: multi-topic decision must be superseded when any
+    of its topics is contradicted."""
+    g, old_id = _graph_with_decision(
+        tmp_path, "Use FastAPI with SQLAlchemy and PostgreSQL for the backend")
+    hits = find_contradicting_decisions(
+        "Switch from PostgreSQL to SQLite", "", g._nodes)
+    assert old_id in hits
+
+
+def test_unrelated_topic_does_not_supersede(tmp_path):
+    g, old_id = _graph_with_decision(tmp_path, "Use PostgreSQL for storage")
+    hits = find_contradicting_decisions("Use pytest as the test runner", "", g._nodes)
+    assert old_id not in hits
+
+
+def test_trpc_vs_grpc_supersedes(tmp_path):
+    """Before the fix, 'Go with tRPC' classified as language, so a later
+    gRPC decision never superseded it."""
+    g, old_id = _graph_with_decision(tmp_path, "Go with tRPC for the API layer")
+    hits = find_contradicting_decisions("Use gRPC instead for the API", "", g._nodes)
+    assert old_id in hits
+
+
+def test_supabase_to_firebase_supersedes(tmp_path):
+    g, old_id = _graph_with_decision(tmp_path, "Use Supabase for the backend")
+    hits = find_contradicting_decisions("Switch to Firebase", "", g._nodes)
+    assert old_id in hits
+
+
+def test_same_decision_not_superseded(tmp_path):
+    g, old_id = _graph_with_decision(tmp_path, "Use PostgreSQL for storage")
+    hits = find_contradicting_decisions("Use PostgreSQL for storage", "", g._nodes)
+    assert old_id not in hits
+
+
+# ── AUDIT round 2 (2026-07-10): near-duplicate decision merging ──────────────
+
+def test_containment_variant_merges_not_supersedes(tmp_path):
+    """The demo bug: 'use React for the frontend.' and 'Use React' were
+    emitted from ONE message, became two nodes, and one superseded the
+    other — a bogus 'Changed:' line in every resume. They must merge."""
+    g = GraphMemory(session_id="t-dup", storage_dir=str(tmp_path))
+    id1 = g.add_node(NodeType.DECISION, "use React for the frontend.",
+                     NodeStatus.COMPLETED)
+    id2 = g.add_node(NodeType.DECISION, "Use React", NodeStatus.COMPLETED)
+    assert id1 == id2, "containment variant must merge into the existing node"
+    decisions = [n for n in g._nodes.values() if n.type == NodeType.DECISION]
+    assert len(decisions) == 1
+    assert decisions[0].status == NodeStatus.COMPLETED
+    assert g.get_transitions() == [], "no self-supersession transition"
+
+
+def test_longer_variant_upgrades_label(tmp_path):
+    """When the more specific wording arrives second, keep it."""
+    g = GraphMemory(session_id="t-dup2", storage_dir=str(tmp_path))
+    id1 = g.add_node(NodeType.DECISION, "Use React", NodeStatus.COMPLETED)
+    id2 = g.add_node(NodeType.DECISION, "Use React for the frontend",
+                     NodeStatus.COMPLETED)
+    assert id1 == id2
+    assert g._nodes[id1].label == "Use React for the frontend"
+
+
+def test_merge_does_not_resurrect_superseded(tmp_path):
+    """Re-adding a same-decision variant as COMPLETED must not flip a
+    SUPERSEDED node back to active."""
+    g = GraphMemory(session_id="t-dup3", storage_dir=str(tmp_path))
+    old_id = g.add_node(NodeType.DECISION, "Use React for the frontend",
+                        NodeStatus.COMPLETED)
+    g.add_node(NodeType.DECISION, "Switch to Next.js for the frontend",
+               NodeStatus.COMPLETED)
+    assert g._nodes[old_id].status == NodeStatus.SUPERSEDED
+    again = g.add_node(NodeType.DECISION, "Use React", NodeStatus.COMPLETED)
+    assert again == old_id
+    assert g._nodes[old_id].status == NodeStatus.SUPERSEDED
+
+
+def test_containment_needs_two_words():
+    """{postgresql} alone must NOT collapse into 'Switch from PostgreSQL
+    to SQLite' — single-word subsets match too many different decisions."""
+    from tokenmizer.graph_memory.decision_tracker import _is_same_decision
+    assert not _is_same_decision("PostgreSQL", "Switch from PostgreSQL to SQLite")
+    assert not _is_same_decision("Use PostgreSQL", "Switch from PostgreSQL to SQLite")
+    assert _is_same_decision("Use React", "use React for the frontend.")
+
+
+def test_real_supersession_still_fires_after_merge_fix(tmp_path):
+    """The merge fix must not swallow genuine contradictions."""
+    g = GraphMemory(session_id="t-dup4", storage_dir=str(tmp_path))
+    old_id = g.add_node(NodeType.DECISION, "Use React for the frontend",
+                        NodeStatus.COMPLETED)
+    new_id = g.add_node(NodeType.DECISION, "Switch to Next.js for the frontend",
+                        NodeStatus.COMPLETED)
+    assert new_id != old_id
+    assert g._nodes[old_id].status == NodeStatus.SUPERSEDED
+    assert len(g.get_transitions()) == 1

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -125,8 +125,27 @@ class TestPruning:
 
     def test_prune_preserves_decisions(self, graph):
         import time
-        for i in range(10):
-            nid = graph.add_node(NodeType.DECISION, f"Use SQLite for local storage {i}", NodeStatus.COMPLETED)
+        # Ten genuinely distinct decisions in DIFFERENT topic buckets.
+        # (The old fixture used "Use SQLite for local storage {i}" — labels
+        # differing only by a trailing digit are 83% word-overlap, which
+        # _is_same_decision has always considered the same decision; since
+        # the 2026-07-10 near-duplicate merge fix, add_node now acts on
+        # that judgment and merges them, so the fixture must use decisions
+        # that are actually distinct.)
+        labels = [
+            "Use PostgreSQL for the primary database",
+            "Use Redis as the cache backend",
+            "Use JWT tokens for the auth mechanism",
+            "Use bcrypt for password hashing",
+            "Use FastAPI as the web framework",
+            "Use React for the frontend framework",
+            "Deploy on Docker with compose",
+            "Use Kafka as the message queue",
+            "Use S3 for object file storage",
+            "Use pytest as the testing framework",
+        ]
+        for label in labels:
+            nid = graph.add_node(NodeType.DECISION, label, NodeStatus.COMPLETED)
             assert nid != ""
             graph._nodes[nid].updated_at = time.time() - 100 * 86400
 
@@ -180,3 +199,41 @@ class TestPersistence:
         task_node = next(n for n in g2._nodes.values() if n.type == NodeType.TASK)
         assert task_node.label == "Implement auth"
         assert task_node.status == NodeStatus.COMPLETED
+
+
+class TestArchivedReachability:
+    """
+    AUDIT FIX (2026-07-10): ARCHIVED was a documented, fully-wired status
+    (decay rates, prune rules, query filters all handled it) that NOTHING
+    ever set — the README advertised a 4-state model whose 4th state was
+    unreachable. SUPERSEDED decisions now age into ARCHIVED after
+    GraphMemory.ARCHIVE_SUPERSEDED_AFTER_DAYS days (from supersession time).
+    """
+
+    def test_superseded_decision_ages_into_archived(self, graph):
+        import time as _time
+        old_id = graph.add_node(NodeType.DECISION, "Use PostgreSQL for storage",
+                                NodeStatus.COMPLETED)
+        graph.add_node(NodeType.DECISION, "Switch to MySQL for storage",
+                       NodeStatus.COMPLETED)
+        old = graph._nodes[old_id]
+        assert old.status == NodeStatus.SUPERSEDED, "precondition: supersession fired"
+
+        # Simulate 8 days passing since supersession
+        old.valid_until = _time.time() - 8 * 86400
+        graph.apply_importance_decay()
+        assert old.status == NodeStatus.ARCHIVED
+
+    def test_recently_superseded_decision_not_archived(self, graph):
+        old_id = graph.add_node(NodeType.DECISION, "Use PostgreSQL for storage",
+                                NodeStatus.COMPLETED)
+        graph.add_node(NodeType.DECISION, "Switch to MySQL for storage",
+                       NodeStatus.COMPLETED)
+        graph.apply_importance_decay()
+        assert graph._nodes[old_id].status == NodeStatus.SUPERSEDED
+
+    def test_active_decisions_never_archived(self, graph):
+        nid = graph.add_node(NodeType.DECISION, "Use PostgreSQL for storage",
+                             NodeStatus.COMPLETED)
+        graph.apply_importance_decay()
+        assert graph._nodes[nid].status == NodeStatus.COMPLETED

--- a/tests/unit/test_hybrid_extractor.py
+++ b/tests/unit/test_hybrid_extractor.py
@@ -146,3 +146,83 @@ async def test_extract_without_provider():
     # (mathematically always true). Heuristic-only extraction should still
     # find "api/auth.py", which is explicitly present in MESSAGES.
     assert len(result.files) >= 1, "Heuristic-only extraction should find at least one file"
+
+
+@pytest.mark.asyncio
+async def test_extract_llm_pass_actually_invoked_app_style():
+    """
+    REGRESSION (2026-07-10 audit): api/app.py's background extraction did
+      HybridExtractor(provider_fn=_pfn)   → TypeError (no such kwarg), and
+      ext.extract(_msgs)                  → provider_fn=None, LLM pass skipped.
+    So the LLM extraction path NEVER ran in production — every call raised,
+    was caught by the broad except, and logged as a provider failure.
+
+    This test replicates the app.py call pattern exactly as fixed:
+    construct with defaults, pass provider_fn to extract(), and assert
+    the provider was actually called and its output merged in.
+    """
+    calls = []
+
+    async def _pfn(messages, system="", max_tokens=600):
+        calls.append(len(messages))
+        return {"text": (
+            '{"goals": [], "tasks_done": [], "tasks_wip": [],'
+            ' "decisions": [{"label": "use Vitest for testing", "reason": "speed"}],'
+            ' "files": ["src/only_llm_saw_this.ts"], "errors": [],'
+            ' "dependencies": [], "environments": [], "superseded": []}'
+        )}
+
+    ext = HybridExtractor()
+    result = await ext.extract(MESSAGES, provider_fn=_pfn)
+
+    assert calls, "provider_fn was never invoked — LLM pass silently skipped"
+    assert "src/only_llm_saw_this.ts" in result.files, (
+        f"LLM-only file missing from merged output: {result.files}"
+    )
+
+
+class TestMinConfidenceFilter:
+    """
+    AUDIT round 2 (2026-07-10): min_confidence was dead code — stored in
+    __init__, never read. It now filters extract() output by merge()'s
+    confidence tiers (0.95 corroborated / 0.80 LLM-only / 0.65 heuristic-
+    only). Default 0.55 keeps everything (backward compatible).
+    """
+
+    def test_default_keeps_heuristic_only_items(self):
+        ext = HybridExtractor()  # default 0.55
+        merged = ext._filter_by_confidence(ext.merge(None, ext.heuristic_extract(MESSAGES)))
+        assert merged.files, "default threshold must not drop heuristic-only items"
+
+    def test_strict_threshold_drops_heuristic_only_category(self):
+        ext = HybridExtractor(min_confidence=0.9)
+        llm = ExtractedData(files=["api/auth.py"])          # corroborated below
+        heu = ExtractedData(files=["api/auth.py"],          # -> files tier 0.95
+                            errors=["timeout in worker"])    # -> errors tier 0.65
+        merged = ext._filter_by_confidence(ext.merge(llm, heu))
+        assert merged.files == ["api/auth.py"], "corroborated tier must survive"
+        assert merged.errors == [], "heuristic-only tier must be dropped at 0.9"
+
+    def test_per_item_decision_filtering(self):
+        ext = HybridExtractor(min_confidence=0.9)
+        llm = ExtractedData(decisions=[
+            {"label": "use bcrypt for hashing", "reason": ""},   # corroborated -> 0.95
+            {"label": "use Vitest for tests", "reason": ""},     # llm-only -> 0.80
+        ])
+        heu = ExtractedData(decisions=[
+            {"label": "use bcrypt for hashing", "reason": ""},
+            {"label": "use Redis for cache", "reason": ""},      # heuristic-only -> 0.65
+        ])
+        merged = ext._filter_by_confidence(ext.merge(llm, heu))
+        labels = [d["label"] for d in merged.decisions]
+        assert labels == ["use bcrypt for hashing"], (
+            f"only the corroborated decision survives 0.9, got {labels}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_extract_applies_filter_end_to_end(self):
+        ext = HybridExtractor(min_confidence=0.9)
+        result = await ext.extract(MESSAGES, provider_fn=None)  # all heuristic-only
+        assert result.files == [] and result.decisions == [], (
+            "heuristic-only extraction at min_confidence=0.9 must yield nothing"
+        )

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,198 @@
+"""
+Regression tests for the MCP stdio server (2026-07-10 audit).
+
+Bugs these guard against (all confirmed live before the fix):
+  1. isError was computed via result_text.startswith("❌") — a KeyError from
+     a missing required argument surfaced as "Tool error: 'session_id'" with
+     isError FALSE, i.e. clients saw a *successful* result.
+  2. A valid-JSON-but-not-an-object line ([1,2]) crashed the whole server
+     via AttributeError on req.get().
+  3. Any exception in a handler outside tools/call (e.g. initialize) killed
+     the process with no JSON-RPC error — the client hung, then saw the
+     subprocess die.
+  4. Malformed JSON lines were silently dropped (no log, no error response).
+"""
+import io
+import json
+import sys
+
+from tokenmizer.mcp import server as mcp
+
+# ── handle_tool_call: structural isError ─────────────────────────────────────
+
+def test_missing_required_arg_is_error():
+    text, is_error = mcp.handle_tool_call("checkpoint_session", {})
+    assert is_error is True
+    assert "session_id" in text
+
+
+def test_missing_arg_resume_is_error():
+    text, is_error = mcp.handle_tool_call("resume_session", {})
+    assert is_error is True
+    assert "session_id" in text
+
+
+def test_invalid_level_is_error():
+    text, is_error = mcp.handle_tool_call(
+        "resume_session", {"session_id": "s1", "level": "verbose"})
+    assert is_error is True
+    assert "level" in text
+
+
+def test_unknown_tool_is_error():
+    text, is_error = mcp.handle_tool_call("no_such_tool", {})
+    assert is_error is True
+    assert "no_such_tool" in text
+
+
+def test_non_dict_arguments_is_error():
+    text, is_error = mcp.handle_tool_call("checkpoint_session", [1, 2])
+    assert is_error is True
+    assert "JSON object" in text
+
+
+def test_bad_token_budget_is_error():
+    text, is_error = mcp.handle_tool_call(
+        "analyze_file", {"file_path": "x.csv", "token_budget": "500"})
+    assert is_error is True
+    assert "token_budget" in text
+
+
+def test_bool_token_budget_rejected():
+    # bool is an int subclass — must not sneak through the isinstance check
+    text, is_error = mcp.handle_tool_call(
+        "analyze_file", {"file_path": "x.csv", "token_budget": True})
+    assert is_error is True
+
+
+def test_file_not_found_is_error(tmp_path):
+    text, is_error = mcp.handle_tool_call(
+        "analyze_file", {"file_path": str(tmp_path / "nope.csv")})
+    assert is_error is True
+    assert "not found" in text.lower()
+
+
+def test_analyze_file_success_not_error(tmp_path):
+    f = tmp_path / "data.csv"
+    f.write_text("region,revenue\nEMEA,100\nAPAC,200\n")
+    text, is_error = mcp.handle_tool_call("analyze_file", {"file_path": str(f)})
+    assert is_error is False
+    assert "File Analysis" in text
+
+
+def test_handler_crash_is_error_not_exception(monkeypatch):
+    def boom(args):
+        raise RuntimeError("kaboom")
+    # handle_tool_call builds its dispatch dict from module globals at call
+    # time, so patching the module attribute is picked up.
+    monkeypatch.setattr(mcp, "handle_get_savings_stats", boom)
+    text, is_error = mcp.handle_tool_call("get_savings_stats", {})
+    assert is_error is True
+    assert "kaboom" in text or "internal error" in text.lower()
+
+
+# ── stdio transport: survives hostile input ──────────────────────────────────
+
+def _run_lines(monkeypatch, lines: list[str]) -> list[dict]:
+    """Feed lines to run_stdio_server, return parsed JSON responses."""
+    stdin = io.StringIO("\n".join(lines) + "\n")
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdin", stdin)
+    monkeypatch.setattr(sys, "stdout", stdout)
+    mcp.run_stdio_server()
+    return [json.loads(ln) for ln in stdout.getvalue().splitlines() if ln.strip()]
+
+
+def test_stdio_initialize_handshake(monkeypatch):
+    out = _run_lines(monkeypatch, [
+        json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    ])
+    assert out[0]["id"] == 1
+    assert out[0]["result"]["protocolVersion"] == "2024-11-05"
+    assert out[0]["result"]["serverInfo"]["name"] == "tokenmizer"
+
+
+def test_stdio_survives_malformed_json(monkeypatch):
+    """Malformed line → parse error response, next request still served."""
+    out = _run_lines(monkeypatch, [
+        "{this is not json",
+        json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    ])
+    assert out[0]["error"]["code"] == -32700
+    assert out[1]["id"] == 2
+    assert len(out[1]["result"]["tools"]) == 5
+
+
+def test_stdio_survives_non_object_json(monkeypatch):
+    """[1,2] is valid JSON but not a request object — was a server-killer."""
+    out = _run_lines(monkeypatch, [
+        "[1, 2]",
+        '"just a string"',
+        json.dumps({"jsonrpc": "2.0", "id": 3, "method": "tools/list"}),
+    ])
+    assert out[0]["error"]["code"] == -32600
+    assert out[1]["error"]["code"] == -32600
+    assert out[2]["id"] == 3
+
+
+def test_stdio_handler_exception_yields_jsonrpc_error(monkeypatch):
+    """A crash inside request handling → -32603 response, loop survives."""
+    def boom(req, send):
+        raise RuntimeError("handler exploded")
+    real = mcp._handle_request
+    calls = {"n": 0}
+
+    def flaky(req, send):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return boom(req, send)
+        return real(req, send)
+
+    monkeypatch.setattr(mcp, "_handle_request", flaky)
+    out = _run_lines(monkeypatch, [
+        json.dumps({"jsonrpc": "2.0", "id": 4, "method": "tools/list"}),
+        json.dumps({"jsonrpc": "2.0", "id": 5, "method": "tools/list"}),
+    ])
+    assert out[0]["error"]["code"] == -32603
+    assert "handler exploded" in out[0]["error"]["message"]
+    assert out[1]["id"] == 5 and "result" in out[1]
+
+
+def test_stdio_missing_arg_reports_is_error_true(monkeypatch):
+    """THE bug: missing session_id must reach the client as isError: true."""
+    out = _run_lines(monkeypatch, [
+        json.dumps({"jsonrpc": "2.0", "id": 6, "method": "tools/call",
+                    "params": {"name": "checkpoint_session", "arguments": {}}}),
+    ])
+    assert out[0]["result"]["isError"] is True
+    assert "session_id" in out[0]["result"]["content"][0]["text"]
+
+
+def test_stdio_unknown_method_error(monkeypatch):
+    out = _run_lines(monkeypatch, [
+        json.dumps({"jsonrpc": "2.0", "id": 7, "method": "bogus/method"}),
+    ])
+    assert out[0]["error"]["code"] == -32601
+
+
+def test_stdio_notifications_get_no_response(monkeypatch):
+    out = _run_lines(monkeypatch, [
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        json.dumps({"jsonrpc": "2.0", "id": 8, "method": "tools/list"}),
+    ])
+    assert len(out) == 1
+    assert out[0]["id"] == 8
+
+
+def test_tool_schemas_are_valid():
+    """Every tool: name, description, well-formed object inputSchema."""
+    for tool in mcp.TOOLS:
+        assert tool["name"]
+        assert tool["description"]
+        schema = tool["inputSchema"]
+        assert schema["type"] == "object"
+        assert isinstance(schema.get("properties", {}), dict)
+        for req_key in schema.get("required", []):
+            assert req_key in schema["properties"], (
+                f"{tool['name']}: required key {req_key} not in properties"
+            )

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -137,6 +137,29 @@ class TestRedaction:
         cleaned = redact_messages(messages)  # must not raise
         assert "sk-proj" not in cleaned[0]["content"][1]
 
+    # ── AUDIT FIX (2026-07-10): coverage gaps found in the redaction audit ──
+
+    def test_connection_string_password_redacted(self):
+        """A DATABASE_URL password matched NO pattern before this fix —
+        no 'password=' literal, no recognized token prefix."""
+        text = "set DATABASE_URL=postgres://admin:Tr0ub4dor3@db.internal:5432/prod"
+        result = redact(text)
+        assert "Tr0ub4dor3" not in result
+        assert "db.internal" in result, "host must survive — only creds redacted"
+
+    def test_connection_string_no_password_untouched(self):
+        text = "connect to https://db.internal:5432/prod for details"
+        assert "db.internal:5432" in redact(text)
+
+    def test_openrouter_key_redacted(self):
+        assert "abcDEF" not in redact("key: sk-or-v1-abcDEF1234567890abcDEF1234567890")
+
+    def test_huggingface_token_redacted(self):
+        assert "AbCdEf" not in redact("hf_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789")
+
+    def test_xai_key_redacted(self):
+        assert "SECRETGROKKEY" not in redact("xai-SECRETGROKKEY12345678901234")
+
 
 class TestInjectionDetection:
     """

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -184,3 +184,49 @@ class TestGraphIntegration:
                 # The postgres task should not have an edge to auth.py
                 assert (t2, f1) not in edges, \
                     "PostgreSQL task should NOT be linked to api/auth.py"
+
+
+class TestExtractorConfidenceBlending:
+    """
+    AUDIT round 2 (2026-07-10): the validator used to recompute confidence
+    purely from label length/wording and IGNORE the extractor's
+    corroboration signal — a doubly-corroborated short decision
+    ("Use Vitest", 0.95) was rejected while verbose weakly-sourced ones
+    passed on label length. Corroboration now blends in:
+        final = max(heuristic, (heuristic + extractor) / 2)
+    """
+
+    def test_corroborated_short_decision_now_accepted(self):
+        v = GraphValidator(min_confidence=0.65)
+        # Heuristics alone: "Vitest for tests" scores ~0.55 -> rejected
+        alone = v.validate("Vitest for tests", "decision")
+        assert not alone.accepted, (
+            f"precondition changed: heuristics alone now score "
+            f"{alone.confidence} — update this test's premise"
+        )
+        # Corroborated by both LLM and heuristic pass -> accepted
+        corroborated = v.validate("Vitest for tests", "decision",
+                                  extractor_confidence=0.95)
+        assert corroborated.accepted
+        assert corroborated.confidence > alone.confidence
+
+    def test_heuristic_only_tier_does_not_auto_pass(self):
+        """0.65 extractor tier must NOT automatically clear a 0.65
+        threshold — blending is evidence, not an override."""
+        v = GraphValidator(min_confidence=0.65)
+        r = v.validate("Vitest for tests", "decision", extractor_confidence=0.65)
+        assert not r.accepted
+
+    def test_blend_never_lowers_heuristic_score(self):
+        v = GraphValidator(min_confidence=0.50)
+        strong = "Decided to use PostgreSQL because we need concurrent writes"
+        base = v.validate(strong, "decision", summary="benchmarked")
+        blended = v.validate(strong, "decision", summary="benchmarked",
+                             extractor_confidence=0.65)
+        assert blended.confidence >= base.confidence
+
+    def test_hard_rejects_survive_high_extractor_confidence(self):
+        """0.95 corroboration cannot resurrect junk."""
+        v = GraphValidator(min_confidence=0.50)
+        r = v.validate("ok", "decision", extractor_confidence=0.95)
+        assert not r.accepted

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -1,0 +1,68 @@
+"""
+Version-consistency guard.
+
+WHY THIS EXISTS: version drift has shipped repeatedly in this repo —
+the 2026-07-10 audit found `server.json` at 0.2.6 (three releases stale)
+and `.claude-plugin/plugin.json` at 0.2.3 (four releases stale) while
+pyproject said 0.3.1. Any MCP registry or plugin marketplace reading
+those manifests displayed the wrong version. This test makes every
+version pin agree with `tokenmizer.__version__` so drift fails CI on the
+same push that introduces it.
+"""
+import json
+import re
+from pathlib import Path
+
+import tokenmizer
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_pyproject_matches_package():
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert m, "pyproject.toml has no version field"
+    assert m.group(1) == tokenmizer.__version__
+
+
+def test_server_json_matches_package():
+    data = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+    versions = []
+    if "version" in data:
+        versions.append(data["version"])
+    for pkg in data.get("packages", []):
+        if "version" in pkg:
+            versions.append(pkg["version"])
+    assert versions, "server.json has no version fields"
+    for v in versions:
+        assert v == tokenmizer.__version__, (
+            f"server.json pins {v}, package is {tokenmizer.__version__} — "
+            f"the MCP registry would display the wrong version"
+        )
+
+
+def test_plugin_manifest_matches_package():
+    data = json.loads(
+        (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+    assert data["version"] == tokenmizer.__version__, (
+        f"plugin.json pins {data['version']}, package is "
+        f"{tokenmizer.__version__} — plugin marketplaces would display "
+        f"the wrong version"
+    )
+
+
+def test_fastapi_app_version_matches_package():
+    text = (ROOT / "tokenmizer" / "api" / "app.py").read_text(encoding="utf-8")
+    m = re.search(r'version\s*=\s*"(\d+\.\d+\.\d+)"', text)
+    assert m, "app.py FastAPI(version=...) pin not found"
+    assert m.group(1) == tokenmizer.__version__, (
+        f"/docs page would show {m.group(1)}, package is {tokenmizer.__version__}"
+    )
+
+
+def test_changelog_has_entry_for_current_version():
+    text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert f"## [{tokenmizer.__version__}]" in text, (
+        f"CHANGELOG.md has no section for {tokenmizer.__version__} — "
+        f"retitle the [Unreleased] entry before releasing"
+    )

--- a/tokenmizer/__init__.py
+++ b/tokenmizer/__init__.py
@@ -1,6 +1,6 @@
 """TokenMizer — Never lose your AI context again."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __all__ = ["GraphMemory", "CheckpointManager", "get_settings"]
 
 

--- a/tokenmizer/api/app.py
+++ b/tokenmizer/api/app.py
@@ -261,7 +261,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="TokenMizer",
     description="Never lose your AI context again.",
-    version="0.3.1",
+    version="0.3.2",
     lifespan=lifespan,
     docs_url="/docs",
     redoc_url="/redoc",
@@ -420,8 +420,14 @@ async def _update_graph(
                                 )
                                 return {"text": r.text}
 
-                            ext = HybridExtractor(provider_fn=_pfn)
-                            extracted = await ext.extract(_msgs)
+                            # FIXED: was HybridExtractor(provider_fn=_pfn) —
+                            # a kwarg __init__ never accepted, so this raised
+                            # TypeError on EVERY call, and even fixed, extract()
+                            # was called without provider_fn (defaults None →
+                            # LLM pass skipped). The LLM extraction path never
+                            # executed once despite use_llm_extraction=true.
+                            ext = HybridExtractor()
+                            extracted = await ext.extract(_msgs, provider_fn=_pfn)
                             _g.extract_from_messages(_all, incremental=False,
                                                      extracted_data=extracted)
                             logger.debug(f"HybridExtractor complete for {_sid}")
@@ -979,19 +985,29 @@ async def invalidate_decision(session_id: str, decision_label: str, reason: str 
         from tokenmizer.graph_memory.graph import NodeStatus, NodeType
         graph = await _get_graph_async(session_id)
         label_lower = decision_label.lower().strip()
-        found = False
-        for node in graph._nodes.values():
+        # AUDIT FIX (2026-07-10): the substring match previously ran across
+        # ALL decision nodes regardless of status — a short label like
+        # "auth" could flip several nodes at once, including already-
+        # SUPERSEDED history nodes (destroying their supersession record by
+        # overwriting it with INVALIDATED). Now: only ACTIVE (COMPLETED)
+        # decisions are eligible, and the response lists exactly which
+        # nodes were affected so multi-matches are visible to the caller.
+        invalidated: list[dict] = []
+        for node_id, node in graph._nodes.items():
             if (node.type == NodeType.DECISION and
+                    node.status == NodeStatus.COMPLETED and
                     label_lower in node.label.lower()):
                 node.status = NodeStatus.INVALIDATED
                 node.summary = (
                     f"Invalidated: {reason[:100]}" if reason else "Explicitly invalidated"
                 )
-                found = True
-        if not found:
+                invalidated.append({"node_id": node_id, "label": node.label})
+        if not invalidated:
             raise HTTPException(
                 status_code=404,
-                detail=f"No decision matching '{decision_label}' found in session '{session_id}'"
+                detail=(f"No ACTIVE decision matching '{decision_label}' found in "
+                        f"session '{session_id}' (superseded/archived decisions "
+                        f"are not invalidatable — they are already inactive)")
             )
         graph._persist(force=True)  # direct node mutation above bypasses add_node's
                                       # dirty-tracking — force=True is required here or
@@ -1001,6 +1017,7 @@ async def invalidate_decision(session_id: str, decision_label: str, reason: str 
         return {
             "session_id": session_id,
             "invalidated": decision_label,
+            "affected_nodes": invalidated,
             "reason": reason,
             "status": "invalidated",
         }

--- a/tokenmizer/cli.py
+++ b/tokenmizer/cli.py
@@ -1,11 +1,24 @@
 """TokenMizer CLI"""
 from __future__ import annotations
 
+import sys
 from typing import Optional
 
 import typer
 from rich.console import Console
 from rich.panel import Panel
+
+# AUDIT FIX (2026-07-10, found by dry-running the README quick start):
+# on Windows consoles using cp1252, the emoji in help/output text raised
+# UnicodeEncodeError — `tokenmizer --help` crashed with a traceback before
+# printing anything. Same fix the benchmark runners already got in v0.2.4;
+# the CLI itself was missed.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except Exception:
+            pass  # non-reconfigurable stream (e.g. pytest capture) — harmless
 
 app = typer.Typer(
     name="tokenmizer",

--- a/tokenmizer/compression/engine.py
+++ b/tokenmizer/compression/engine.py
@@ -331,7 +331,18 @@ class FileContentFilter:
             if len(result) < len(content):
                 return f"[JSON cleaned — {len(content)} → {len(result)} chars]\n{result}"
             return content
-        except (json.JSONDecodeError, Exception):
+        except json.JSONDecodeError:
+            # Not (valid) JSON — expected for non-JSON content routed here;
+            # passing through unchanged is correct and not log-worthy.
+            return content
+        except Exception as e:
+            # AUDIT FIX (2026-07-10): was `except (json.JSONDecodeError,
+            # Exception): return content` — a redundant tuple that swallowed
+            # EVERY error (including bugs in _clean_json, RecursionError on
+            # pathological nesting) with zero logging. Filtering silently
+            # no-oped and the token-savings layer degraded invisibly.
+            logger.warning(f"JSON filtering failed, passing content through "
+                           f"unfiltered: {type(e).__name__}: {e}")
             return content
 
     def _clean_json(self, obj, depth: int):

--- a/tokenmizer/filters/file_intelligence.py
+++ b/tokenmizer/filters/file_intelligence.py
@@ -97,7 +97,11 @@ def detect_file_type(filename: str, content_bytes: bytes) -> str:
         if "," in head and "\n" in head:
             return "csv"
     except Exception as e:
-        logger.debug(f"File type sniff failed, defaulting to text: {e}")
+        # AUDIT FIX (2026-07-10): debug → warning. Misdetecting the type
+        # silently routes the file to the generic text extractor, which can
+        # cost the user most of the promised token savings with no signal.
+        logger.warning(f"File type sniff failed, defaulting to 'text' "
+                       f"(extraction quality degraded): {type(e).__name__}: {e}")
     return "text"
 
 
@@ -546,6 +550,16 @@ class PDFExtractor:
                 # previously this was a bare `except: pass`.
                 logger.debug(f"Failed to extract text from page {i} of {filename}: {e}")
                 page_texts.append("")
+
+        # AUDIT FIX (2026-07-10): per-page failures stay at debug (expected
+        # per-page degradation), but a PDF where NOTHING extracted means the
+        # whole analysis is empty — that must be visible by default.
+        if page_texts and not any(t.strip() for t in page_texts):
+            logger.warning(
+                f"No text extracted from ANY of {len(page_texts)} pages of "
+                f"{filename} (scanned/image-only PDF, or extraction failing "
+                f"on every page) — analysis will be near-empty"
+            )
 
         # Heading structure (lines that look like headings)
         headings = self._extract_headings(page_texts)

--- a/tokenmizer/graph_memory/decision_tracker.py
+++ b/tokenmizer/graph_memory/decision_tracker.py
@@ -63,8 +63,14 @@ _TOPIC_KEYWORDS: dict[str, list[str]] = {
                          "file storage", "object storage", "media storage"],
 
     # Language / runtime
-    "language":         ["python", "typescript", "javascript", "go", "rust",
-                         "java", "kotlin", "programming language"],
+    # AUDIT FIX (2026-07-10): bare "go" removed — the imperative verb
+    # ("Go with tRPC") collided with Go-the-language and misclassified
+    # API-style decisions as language decisions. Go is now detected only
+    # via unambiguous forms: "golang", or the bigrams below.
+    "language":         ["python", "typescript", "javascript", "golang", "rust",
+                         "java", "kotlin", "programming language",
+                         "in go", "use go", "go language", "go backend",
+                         "go service", "go rewrite"],
     "runtime":          ["node", "deno", "bun", "python version", "runtime"],
 
     # Architecture
@@ -74,6 +80,28 @@ _TOPIC_KEYWORDS: dict[str, list[str]] = {
                          "architecture", "system design"],
     "testing":          ["pytest", "jest", "vitest", "cypress", "playwright",
                          "testing framework", "test runner"],
+
+    # AUDIT FIX (2026-07-10): vocabulary gaps — hybrid_extractor.py's
+    # decision regexes knew tech names (supabase, clerk, ...) this file
+    # didn't, so those decisions classified as None and supersession
+    # silently never fired ("Use Supabase" → "Switch to Firebase" left
+    # both looking active). Buckets below close the drift.
+    "backend_platform": ["supabase", "firebase", "appwrite", "pocketbase",
+                         "convex", "amplify", "backend platform", "baas"],
+    "auth_provider":    ["clerk", "auth0", "supertokens", "keycloak",
+                         "cognito", "okta", "nextauth", "next auth",
+                         "firebase auth", "auth provider"],
+    "payments":         ["stripe", "paddle", "braintree", "lemonsqueezy",
+                         "razorpay", "payment provider", "payment gateway"],
+    "observability":    ["sentry", "datadog", "grafana", "prometheus",
+                         "honeycomb", "new relic", "error tracking",
+                         "monitoring tool"],
+    "state_management": ["redux", "zustand", "mobx", "recoil", "jotai",
+                         "pinia", "state management"],
+    "package_manager":  ["npm", "pnpm", "yarn", "poetry", "pipenv",
+                         "package manager"],
+    "styling":          ["tailwind", "styled components", "css framework",
+                         "sass", "css modules"],
 }
 
 # Reverse map: keyword → topic
@@ -83,19 +111,21 @@ for _topic, _keywords in _TOPIC_KEYWORDS.items():
         _KEYWORD_TO_TOPIC[_kw.lower()] = _topic
 
 
-def classify_topic(label: str, summary: str = "") -> Optional[str]:
+def _classify_ordered(label: str, summary: str = "") -> list[str]:
     """
-    Classify a decision label into a topic bucket.
-    Returns topic string if matched, None if unknown.
+    All topic buckets matched by a decision, in match order (bigrams first,
+    then single words, each in word order), deduplicated.
 
-    Examples:
-      "Use PostgreSQL for storage" → "database"
-      "JWT over sessions"          → "auth_mechanism"
-      "Deploy on Railway"          → "deployment"
-      "Use Next.js."               → "frontend"  (trailing period stripped)
-      "Some custom thing"          → None
+    AUDIT FIX (2026-07-10): the old classifier returned on the FIRST
+    single-word hit, so "Use FastAPI with SQLAlchemy and PostgreSQL"
+    classified only as web_framework — a later "switch Postgres to SQLite"
+    was never detected as contradicting it, leaving a stale DB decision
+    active in resume context. All matched topics are now returned.
+
+    Bigrams are matched first and consume their words so that e.g.
+    "session store" (cache_backend) doesn't also leak a spurious
+    auth_mechanism match from the bare word "session".
     """
-    # Strip trailing punctuation before classification
     label = label.rstrip(".,!?;:")
     text = (label + " " + summary).lower()
     # Remove punctuation for matching — but preserve version numbers
@@ -104,18 +134,50 @@ def classify_topic(label: str, summary: str = "") -> Optional[str]:
     text = text.replace("next.js", "nextjs").replace("node.js", "nodejs")
     words = text.split()
 
-    # Check single words first
-    for word in words:
-        if word in _KEYWORD_TO_TOPIC:
-            return _KEYWORD_TO_TOPIC[word]
+    topics: list[str] = []
+    consumed = [False] * len(words)
 
-    # Check bigrams (e.g. "task queue", "message broker")
+    # Bigrams first (consume both words on match)
     for i in range(len(words) - 1):
         bigram = words[i] + " " + words[i + 1]
         if bigram in _KEYWORD_TO_TOPIC:
-            return _KEYWORD_TO_TOPIC[bigram]
+            topic = _KEYWORD_TO_TOPIC[bigram]
+            if topic not in topics:
+                topics.append(topic)
+            consumed[i] = consumed[i + 1] = True
 
-    return None
+    # Single words on whatever the bigrams didn't consume
+    for i, word in enumerate(words):
+        if consumed[i]:
+            continue
+        if word in _KEYWORD_TO_TOPIC:
+            topic = _KEYWORD_TO_TOPIC[word]
+            if topic not in topics:
+                topics.append(topic)
+
+    return topics
+
+
+def classify_topics(label: str, summary: str = "") -> set[str]:
+    """
+    Classify a decision into ALL topic buckets it touches.
+
+    Examples:
+      "Use PostgreSQL for storage"                → {"database"}
+      "Use FastAPI with SQLAlchemy and Postgres"  → {"web_framework", "orm", "database"}
+      "Some custom thing"                         → set()
+    """
+    return set(_classify_ordered(label, summary))
+
+
+def classify_topic(label: str, summary: str = "") -> Optional[str]:
+    """
+    Backward-compatible singular form: the primary (first-matched) topic,
+    or None if nothing matched. Prefer classify_topics() in new code —
+    multi-topic decisions lose information here by construction.
+    """
+    ordered = _classify_ordered(label, summary)
+    return ordered[0] if ordered else None
 
 
 def find_contradicting_decisions(
@@ -142,10 +204,10 @@ def find_contradicting_decisions(
     """
     from tokenmizer.graph_memory.graph import NodeStatus, NodeType
 
-    new_topic = classify_topic(new_label, new_summary)
+    new_topics = classify_topics(new_label, new_summary)
 
     # If topic unknown, use word overlap as fallback
-    if new_topic is None:
+    if not new_topics:
         return _find_by_word_overlap(new_label, existing_nodes)
 
     to_supersede = []
@@ -155,8 +217,17 @@ def find_contradicting_decisions(
         if node.status not in (NodeStatus.COMPLETED,):
             continue  # already superseded/archived/invalidated — skip
 
-        existing_topic = classify_topic(node.label, node.summary)
-        if existing_topic == new_topic:
+        # AUDIT FIX (2026-07-10): topic comparison is now SET INTERSECTION,
+        # not equality of a single first-match topic. A multi-topic decision
+        # ("FastAPI + SQLAlchemy + PostgreSQL") is contradicted by a new
+        # decision touching ANY of its topics ("switch Postgres to SQLite").
+        # Trade-off (deliberate): the whole node is superseded even though
+        # its other topics (FastAPI) may still hold — the graph's granularity
+        # is one node per decision *statement*, and the supersession
+        # transition records both labels, so no information is lost; the
+        # alternative (leaving it active) showed stale decisions as current.
+        existing_topics = classify_topics(node.label, node.summary)
+        if existing_topics & new_topics:
             # Same topic — check it's not the same decision
             if not _is_same_decision(new_label, node.label):
                 to_supersede.append(node_id)
@@ -221,5 +292,18 @@ def _is_same_decision(label_a: str, label_b: str) -> bool:
     words_b = set(b.split())
     if not words_a or not words_b:
         return False
+    # AUDIT FIX (2026-07-10, round 2): containment. "Use React" and
+    # "use React for the frontend." are the same decision, but flat word
+    # overlap scores them 2/5 = 0.4 — far below the 0.82 threshold. The
+    # extractor can emit both variants from ONE message (different regex
+    # passes capture different spans), and without this check they became
+    # two nodes where one superseded the other — a self-supersession that
+    # polluted the resume context with a bogus "Changed:" line.
+    # Guard: the smaller set needs >= 2 words, so "Use PostgreSQL" is NOT
+    # collapsed into "Switch from PostgreSQL to SQLite" ({postgresql}
+    # alone would be a subset of many genuinely different decisions).
+    smaller, larger = (words_a, words_b) if len(words_a) <= len(words_b) else (words_b, words_a)
+    if len(smaller) >= 2 and smaller <= larger:
+        return True
     overlap = len(words_a & words_b) / max(len(words_a), len(words_b))
     return overlap >= 0.82

--- a/tokenmizer/graph_memory/graph.py
+++ b/tokenmizer/graph_memory/graph.py
@@ -68,6 +68,10 @@ class GraphMemory:
     Survives process restarts. One DB file per storage_dir.
     """
 
+    # Days a decision stays SUPERSEDED before aging into ARCHIVED
+    # (measured from the moment of supersession — see apply_importance_decay).
+    ARCHIVE_SUPERSEDED_AFTER_DAYS: float = 7.0
+
     def __init__(self, session_id: str, storage_dir: str = "./checkpoints"):
         self.session_id = session_id
         self._nodes: dict[str, MemoryNode] = {}
@@ -125,8 +129,15 @@ class GraphMemory:
         - check_same_thread=False: safe because we serialize via asyncio session locks
         """
         conn = sqlite3.connect(str(self._db_path), timeout=5.0, check_same_thread=False)
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA synchronous=NORMAL")  # WAL + NORMAL = safe + fast
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")  # WAL + NORMAL = safe + fast
+        except Exception:
+            # AUDIT FIX (2026-07-10): same leak as checkpoints/manager.py —
+            # a corrupt DB file failed the PRAGMA and leaked the open handle,
+            # which on Windows blocked the delete-and-recreate recovery path.
+            conn.close()
+            raise
         return conn
 
     def _init_db(self) -> None:
@@ -213,7 +224,19 @@ class GraphMemory:
             finally:
                 conn.close()
         except Exception as e:
-            logger.debug(f"Transition load skipped (table may not exist yet): {e}")
+            # AUDIT FIX (2026-07-10): everything logged at debug here, so DB
+            # corruption or a schema mismatch looked identical to the benign
+            # first-run case — decision history silently "didn't exist".
+            # The benign case (table not created yet) stays at debug; every
+            # other failure is now visible by default.
+            if "no such table" in str(e).lower():
+                logger.debug(f"Transition load skipped (first run, table not "
+                             f"created yet): {e}")
+            else:
+                logger.warning(f"Transition load FAILED for session "
+                               f"{self.session_id} — decision supersession "
+                               f"history unavailable this session: "
+                               f"{type(e).__name__}: {e}")
             self._transitions = []
 
     def _persist(self, force: bool = False) -> None:
@@ -418,12 +441,50 @@ class GraphMemory:
                 existing.summary = summary
             return node_id
 
-        # Validate before inserting — reject noise and low-confidence nodes
+        # AUDIT FIX (2026-07-10, round 2): fuzzy same-decision merge.
+        # The exact-hash dedup above only catches identical normalized
+        # labels, but the extractor can emit near-duplicate decisions from
+        # ONE message ("Use React" + "use React for the frontend." — two
+        # regex passes, different capture spans). Those became two nodes,
+        # and since they share a topic, one SUPERSEDED the other — a bogus
+        # self-supersession that showed up as a noisy "Changed:" line in
+        # every resume. Merge them instead: keep the existing node, prefer
+        # the longer (more specific) label, backfill the summary.
+        if node_type == NodeType.DECISION:
+            from tokenmizer.graph_memory.decision_tracker import _is_same_decision
+            for ex_id, ex in self._nodes.items():
+                if ex.type != NodeType.DECISION or ex._evicted:
+                    continue
+                if _is_same_decision(label, ex.label):
+                    ex.touch()
+                    self._dirty = True
+                    # Same status-upgrade-only rule as the exact-dedup branch
+                    # (a COMPLETED re-add must not resurrect a SUPERSEDED node)
+                    _rank = {
+                        NodeStatus.PENDING: 0, NodeStatus.IN_PROGRESS: 1,
+                        NodeStatus.COMPLETED: 2, NodeStatus.FAILED: 3,
+                        NodeStatus.ARCHIVED: 4, NodeStatus.SUPERSEDED: 5,
+                        NodeStatus.MODIFIED: 5, NodeStatus.INVALIDATED: 6,
+                    }
+                    if _rank.get(status, 0) > _rank.get(ex.status, 0):
+                        ex.status = status
+                    if len(label) > len(ex.label) and status == ex.status:
+                        ex.label = label[:120]
+                    if summary and not ex.summary:
+                        ex.summary = summary[:300]
+                    return ex_id
+
+        # Validate before inserting — reject noise and low-confidence nodes.
+        # confidence != 0.7 means the caller supplied an explicit value —
+        # for extraction-sourced decisions that's merge()'s corroboration
+        # tier (0.95/0.80/0.65), which the validator blends into its own
+        # score instead of ignoring (see validator.validate docstring).
         validator = _get_validator()
         result = validator.validate(
             label=label,
             node_type=node_type.value,
             summary=summary,
+            extractor_confidence=confidence if confidence != 0.7 else None,
         )
         if not result.accepted:
             logger.debug(f"Node rejected: {label!r} ({result.rejection_reason})")
@@ -972,6 +1033,26 @@ class GraphMemory:
         Returns: dict of {node_id: new_importance} for changed nodes
         """
         changed: dict[str, float] = {}
+
+        # AUDIT FIX (2026-07-10): ARCHIVED was a documented status, fully
+        # wired into decay/prune/query filtering — but NOTHING ever set it.
+        # The README's 4-state model advertised a state that was unreachable.
+        # Now: SUPERSEDED decisions age into ARCHIVED once they've been
+        # superseded for ARCHIVE_SUPERSEDED_AFTER_DAYS (measured from
+        # valid_until, the moment of supersession — not node creation).
+        # This matches the README's "SUPERSEDED shown in resume ⚠ 7 days".
+        _now = time.time()
+        for _nid, _node in self._nodes.items():
+            if (_node.type == NodeType.DECISION
+                    and _node.status == NodeStatus.SUPERSEDED
+                    and not _node._evicted
+                    and _node.valid_until > 0.0
+                    and (_now - _node.valid_until) / 86400.0
+                        >= self.ARCHIVE_SUPERSEDED_AFTER_DAYS):
+                _node.status = NodeStatus.ARCHIVED
+                self._dirty = True
+                logger.debug(f"Archived long-superseded decision {_nid}: "
+                             f"{_node.label[:60]}")
 
         # Decay rates per day
         _DECAY_RATE = {

--- a/tokenmizer/graph_memory/hybrid_extractor.py
+++ b/tokenmizer/graph_memory/hybrid_extractor.py
@@ -279,6 +279,10 @@ class HybridExtractor:
       - Corroborated items (both passes agree) → confidence 0.95
       - LLM-only items → confidence 0.80
       - Heuristic-only items → confidence 0.65
+
+    min_confidence: items below this tier are dropped from extract()'s
+    output. Default 0.55 keeps every tier (backward compatible); 0.7
+    drops heuristic-only items; 0.9 keeps only corroborated ones.
     """
 
     def __init__(self, min_confidence: float = 0.55):
@@ -315,8 +319,18 @@ class HybridExtractor:
             raw = re.sub(r"```json\s*|```\s*", "", raw).strip()
             data = json.loads(raw)
             return self._dict_to_extracted(data)
-        except (json.JSONDecodeError, KeyError, Exception) as e:
-            logger.debug(f"LLM extraction failed: {e}")
+        except Exception as e:
+            # FIXED: was `except (json.JSONDecodeError, KeyError, Exception)`
+            # (redundant tuple — Exception covers both) logging at `debug`,
+            # which is off by default in production. A provider timeout,
+            # rate limit, or malformed JSON reply silently degraded every
+            # turn to heuristic-only extraction with zero visible trace —
+            # the same invisible-failure pattern already fixed at the
+            # api/app.py call site. Now warning, consistent with that fix.
+            logger.warning(
+                f"LLM extraction failed (falling back to heuristic-only "
+                f"for this batch): {type(e).__name__}: {e}"
+            )
             return None
 
     def _dict_to_extracted(self, data: dict) -> ExtractedData:
@@ -689,8 +703,37 @@ class HybridExtractor:
         # Pass 2: Heuristic (always runs)
         heu_result = self.heuristic_extract(messages)
 
-        # Pass 3: Merge
-        return self.merge(llm_result, heu_result)
+        # Pass 3: Merge, then filter by min_confidence
+        return self._filter_by_confidence(self.merge(llm_result, heu_result))
+
+    def _filter_by_confidence(self, merged: ExtractedData) -> ExtractedData:
+        """
+        Drop extracted items whose merge() confidence tier is below
+        self.min_confidence.
+
+        AUDIT FIX (2026-07-10, round 2): min_confidence was dead code —
+        stored in __init__ and never read again, while the class docstring
+        implied it gated inclusion. Now it does what it says. The default
+        (0.55) sits below the lowest tier (heuristic-only, 0.65), so
+        default behavior is unchanged; raising it is how you opt into
+        stricter extraction (e.g. 0.7 drops heuristic-only items, 0.9
+        keeps only corroborated ones).
+        """
+        if self.min_confidence <= 0.65:  # lowest tier — nothing can be dropped
+            return merged
+        # Decisions carry per-item confidence tags from merge()
+        merged.decisions = [
+            d for d in merged.decisions
+            if d.get("confidence", 0.65) >= self.min_confidence
+        ]
+        # Simple-list categories share one tier per category
+        for attr, tier in merged.confidence.items():
+            if attr == "decisions":
+                continue
+            if isinstance(tier, (int, float)) and tier < self.min_confidence \
+                    and isinstance(getattr(merged, attr, None), list):
+                setattr(merged, attr, [])
+        return merged
 
 
 # Singleton

--- a/tokenmizer/graph_memory/validator.py
+++ b/tokenmizer/graph_memory/validator.py
@@ -86,10 +86,33 @@ class GraphValidator:
         node_type: str,
         summary: str = "",
         source_role: str = "assistant",
+        extractor_confidence: float | None = None,
     ) -> ValidationResult:
         """
         Validate a candidate node.
         Returns ValidationResult with accepted=True/False and confidence score.
+
+        extractor_confidence: the corroboration-based confidence computed by
+        HybridExtractor.merge() (0.95 = both LLM and heuristic found it,
+        0.80 = LLM-only, 0.65 = heuristic-only), when the candidate came
+        through the extraction pipeline.
+
+        AUDIT FIX (2026-07-10, round 2): this validator used to recompute
+        confidence purely from label length/wording and IGNORE the
+        extractor's corroboration signal for the accept/reject decision —
+        so a doubly-corroborated but short decision ("Use Vitest", 0.95)
+        scored 0.60 and was rejected, while a verbose weakly-sourced one
+        passed on label length alone. Corroboration now counts as evidence:
+
+            final = max(heuristic_score, (heuristic_score + extractor) / 2)
+
+        - monotone: extractor evidence can only RAISE the score, never
+          lower a label the heuristics already trust;
+        - equal-weight blend, not override: a corroborated candidate still
+          needs non-junk heuristics to clear the threshold, so heuristic-
+          only 0.65 does not automatically pass a 0.65 threshold;
+        - hard rejects (noise labels/patterns) fire before this and are
+          absolute — 0.95 corroboration cannot resurrect junk.
         """
         label = label.strip()
 
@@ -161,6 +184,11 @@ class GraphValidator:
             confidence += 0.05
 
         confidence = max(0.0, min(1.0, confidence))
+
+        # Blend in the extractor's corroboration signal (see docstring)
+        if extractor_confidence is not None:
+            blended = (confidence + max(0.0, min(1.0, extractor_confidence))) / 2
+            confidence = round(max(confidence, blended), 3)
 
         # ── Final decision ────────────────────────────────────────────────────
 

--- a/tokenmizer/graph_memory/visualization.py
+++ b/tokenmizer/graph_memory/visualization.py
@@ -229,85 +229,331 @@ def to_obsidian_canvas(graph: "GraphMemory") -> dict:
 
 
 # ── Shareable standalone HTML (the "look at my session's brain" artifact) ────
+#
+# REDESIGNED (2026-07-10 audit): the previous version was exactly the
+# "generic Obsidian-style node soup" it claimed to beat —
+#   - to_vis_json() exported `transitions` (the supersession history, the
+#     ONE thing this product tracks that generic graph views don't), and
+#     the HTML template never used them;
+#   - superseded decisions were only lower-opacity circles;
+#   - no filtering, no search, no export;
+#   - it loaded D3 from a CDN, so the "self-contained" artifact broke
+#     offline and in network-restricted demo environments.
+# Now: zero external dependencies (hand-rolled force layout, ~2KB of JS),
+# supersession arcs + a clickable decision-history timeline, per-type
+# filter chips, active-only toggle, search, wheel-zoom/pan, PNG export.
 
 _SHARE_HTML_TEMPLATE = """<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>TokenMizer — __SESSION__</title>
-<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
 <style>
- body{margin:0;background:#0d1117;color:#c9d1d9;font:14px/1.4 'Segoe UI',system-ui,sans-serif;overflow:hidden}
- #hdr{position:fixed;top:0;left:0;right:0;padding:14px 22px;display:flex;gap:18px;align-items:baseline;
-      background:linear-gradient(#0d1117ee,#0d111700);z-index:2;pointer-events:none}
+ :root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--txt:#c9d1d9;--dim:#8b949e;--hi:#5ee7c8;--red:#f87171}
+ body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.45 'Segoe UI',system-ui,sans-serif;overflow:hidden}
+ #hdr{position:fixed;top:0;left:0;right:340px;padding:14px 22px;display:flex;gap:18px;align-items:baseline;
+      background:linear-gradient(#0d1117f0,#0d111700);z-index:3;pointer-events:none}
  #hdr b{font-size:18px;color:#e6edf3}
- #hdr .stat{color:#8b949e}#hdr .stat i{color:#5ee7c8;font-style:normal;font-weight:600}
- #legend{position:fixed;bottom:44px;left:22px;z-index:2;display:flex;flex-wrap:wrap;gap:10px;max-width:70vw}
- #legend span{display:flex;align-items:center;gap:5px;color:#8b949e;font-size:12px}
- #legend i{width:10px;height:10px;border-radius:50%;display:inline-block}
- #ftr{position:fixed;bottom:12px;left:22px;color:#484f58;font-size:12px;z-index:2}
+ #hdr .stat{color:var(--dim)}#hdr .stat i{color:var(--hi);font-style:normal;font-weight:600}
+ #controls{position:fixed;top:54px;left:22px;z-index:3;display:flex;gap:8px;align-items:center;flex-wrap:wrap;max-width:55vw}
+ #controls input[type=search]{background:var(--panel);border:1px solid var(--line);color:var(--txt);
+      border-radius:6px;padding:5px 10px;font:inherit;font-size:12px;width:170px;outline:none}
+ #controls input[type=search]:focus{border-color:var(--hi)}
+ .btn{background:var(--panel);border:1px solid var(--line);color:var(--txt);border-radius:6px;
+      padding:5px 11px;font-size:12px;cursor:pointer;user-select:none}
+ .btn:hover{border-color:var(--hi)}
+ .btn.on{border-color:var(--hi);color:var(--hi)}
+ #chips{position:fixed;bottom:44px;left:22px;z-index:3;display:flex;flex-wrap:wrap;gap:8px;max-width:55vw}
+ .chip{display:flex;align-items:center;gap:6px;color:var(--dim);font-size:12px;cursor:pointer;
+      background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:3px 11px;user-select:none}
+ .chip i{width:9px;height:9px;border-radius:50%;display:inline-block}
+ .chip.off{opacity:0.35}
+ #ftr{position:fixed;bottom:12px;left:22px;color:#484f58;font-size:12px;z-index:3}
  #ftr a{color:#7c6af7;text-decoration:none}
- .node text{fill:#c9d1d9;font-size:11px;pointer-events:none;text-shadow:0 1px 3px #000}
- svg{cursor:grab}svg:active{cursor:grabbing}
+ #timeline{position:fixed;top:0;right:0;bottom:0;width:320px;background:var(--panel);
+      border-left:1px solid var(--line);z-index:4;overflow-y:auto;padding:16px}
+ #timeline h2{font-size:13px;text-transform:uppercase;letter-spacing:1px;color:var(--dim);margin:0 0 4px}
+ #timeline .sub{font-size:12px;color:#484f58;margin-bottom:14px}
+ .tr-item{border:1px solid var(--line);border-radius:8px;padding:10px 12px;margin-bottom:10px;
+      cursor:pointer;transition:border-color .15s}
+ .tr-item:hover,.tr-item.sel{border-color:var(--red)}
+ .tr-item .old{color:var(--dim);text-decoration:line-through;font-size:12px}
+ .tr-item .arrow{color:var(--red);margin:0 4px}
+ .tr-item .new{color:#e6edf3;font-size:13px;font-weight:600}
+ .tr-item .why{color:var(--dim);font-size:12px;margin-top:5px}
+ .tr-item .meta{color:#484f58;font-size:11px;margin-top:4px}
+ .empty{color:#484f58;font-size:13px;border:1px dashed var(--line);border-radius:8px;padding:16px;text-align:center}
+ #tip{position:fixed;pointer-events:none;background:#1c2128;border:1px solid var(--line);border-radius:8px;
+      padding:9px 12px;font-size:12px;max-width:300px;z-index:9;display:none;box-shadow:0 4px 16px #0009}
+ #tip b{color:#e6edf3}#tip .st{color:var(--hi)}
+ svg{cursor:grab;display:block}svg:active{cursor:grabbing}
 </style></head><body>
-<div id="hdr"><b>🧠 __SESSION__</b>
+<div id="hdr"><b>&#129504; __SESSION__</b>
  <span class="stat"><i>__NODES__</i> nodes</span>
  <span class="stat"><i>__EDGES__</i> edges</span>
- <span class="stat"><i>__DECISIONS__</i> decisions tracked</span></div>
-<div id="legend"></div>
-<div id="ftr">session memory graph · <a href="https://github.com/Shweta-Mishra-ai/tokenmizer">TokenMizer</a> · pip install tokenmizer</div>
+ <span class="stat"><i>__DECISIONS__</i> decisions</span>
+ <span class="stat"><i>__TRANSITIONS__</i> changed</span></div>
+<div id="controls">
+ <input id="search" type="search" placeholder="search nodes&#8230;"/>
+ <span class="btn" id="activeOnly">Active only</span>
+ <span class="btn" id="exportPng">&#11123; PNG</span>
+ <span class="btn" id="reheat">&#8635; Layout</span>
+</div>
+<div id="chips"></div>
+<div id="ftr">session memory graph &middot; <a href="https://github.com/Shweta-Mishra-ai/tokenmizer">TokenMizer</a> &middot; pip install tokenmizer</div>
+<div id="timeline">
+ <h2>Decision history</h2>
+ <div class="sub">how this session's choices evolved</div>
+ <div id="trList"></div>
+</div>
+<div id="tip"></div>
 <script>
-const data = __DATA__;
-const COLOR = __COLORS__;
-const W=innerWidth,H=innerHeight;
-const svg=d3.select("body").append("svg").attr("width",W).attr("height",H);
-const defs=svg.append("defs");
-const glow=defs.append("filter").attr("id","glow");
-glow.append("feGaussianBlur").attr("stdDeviation","4").attr("result","b");
-const m=glow.append("feMerge");m.append("feMergeNode").attr("in","b");m.append("feMergeNode").attr("in","SourceGraphic");
-const g=svg.append("g");
-svg.call(d3.zoom().scaleExtent([0.2,4]).on("zoom",e=>g.attr("transform",e.transform)));
-const link=g.selectAll("line").data(data.edges).join("line")
- .attr("stroke",d=>d.color||"#30363d").attr("stroke-opacity",0.45).attr("stroke-width",1.2);
-const node=g.selectAll("g.node").data(data.nodes).join("g").attr("class","node")
- .call(d3.drag().on("start",(e,d)=>{if(!e.active)sim.alphaTarget(0.3).restart();d.fx=d.x;d.fy=d.y})
- .on("drag",(e,d)=>{d.fx=e.x;d.fy=e.y})
- .on("end",(e,d)=>{if(!e.active)sim.alphaTarget(0);d.fx=null;d.fy=null}));
-node.append("circle").attr("r",d=>d.size||10).attr("fill",d=>COLOR[d.type]||"#8b949e")
- .attr("fill-opacity",d=>d.opacity??0.9).attr("filter","url(#glow)")
- .append("title").text(d=>d.type+": "+d.label+(d.summary?" — "+d.summary:""));
-node.append("text").attr("dx",d=>(d.size||10)+4).attr("dy",4)
- .text(d=>d.label.length>34?d.label.slice(0,32)+"…":d.label);
-const sim=d3.forceSimulation(data.nodes)
- .force("link",d3.forceLink(data.edges).id(d=>d.id).distance(90).strength(0.4))
- .force("charge",d3.forceManyBody().strength(-260))
- .force("center",d3.forceCenter(W/2,H/2))
- .force("collide",d3.forceCollide().radius(d=>(d.size||10)+14))
- .on("tick",()=>{link.attr("x1",d=>d.source.x).attr("y1",d=>d.source.y)
- .attr("x2",d=>d.target.x).attr("y2",d=>d.target.y);
- node.attr("transform",d=>`translate(${d.x},${d.y})`)});
-const types=[...new Set(data.nodes.map(d=>d.type))];
-d3.select("#legend").selectAll("span").data(types).join("span")
- .html(t=>`<i style="background:${COLOR[t]||"#8b949e"}"></i>${t}`);
+"use strict";
+const DATA=__DATA__, COLOR=__COLORS__;
+const INACTIVE=new Set(["superseded","archived","invalidated","modified"]);
+// Clamp: innerWidth can be 0 in headless/embedded contexts, and a negative
+// SVG width breaks rendering entirely.
+const W=Math.max(640,(innerWidth||1280)-320), H=Math.max(480,innerHeight||800);
+const NS="http://www.w3.org/2000/svg";
+function el(t,a,p){const e=document.createElementNS(NS,t);for(const k in a)e.setAttribute(k,a[k]);if(p)p.appendChild(e);return e}
+
+const svg=el("svg",{width:W,height:H,"font-family":"Segoe UI,system-ui,sans-serif"},document.body);
+addEventListener("resize",()=>{
+  svg.setAttribute("width",Math.max(640,innerWidth-320));
+  svg.setAttribute("height",Math.max(480,innerHeight));
+});
+const defs=el("defs",{},svg);
+const mk=el("marker",{id:"arr",viewBox:"0 -5 10 10",refX:18,refY:0,markerWidth:7,markerHeight:7,orient:"auto"},defs);
+el("path",{d:"M0,-5L10,0L0,5",fill:"#f87171"},mk);
+const vp=el("g",{},svg);           // viewport (zoom/pan)
+const gE=el("g",{},vp), gT=el("g",{},vp), gN=el("g",{},vp); // edges, transitions, nodes
+
+// ---- data prep -------------------------------------------------------------
+const nodes=DATA.nodes, edges=DATA.edges, trans=DATA.transitions||[];
+const byId={}; nodes.forEach(n=>byId[n.id]=n);
+// seed positions: cluster by type around a circle
+const types=[...new Set(nodes.map(n=>n.type))];
+nodes.forEach((n,i)=>{
+  const a=2*Math.PI*types.indexOf(n.type)/Math.max(types.length,1);
+  n.x=W/2+Math.cos(a)*180+(Math.random()-0.5)*90;
+  n.y=H/2+Math.sin(a)*180+(Math.random()-0.5)*90;
+  n.vx=0;n.vy=0;
+});
+const links=edges.map(e=>({s:byId[e.source],t:byId[e.target],color:e.color}))
+                 .filter(l=>l.s&&l.t);
+const tlinks=trans.map(t=>({s:byId[t.from_id],t:byId[t.to_id],tr:t}))
+                  .filter(l=>l.s&&l.t);
+
+// ---- hand-rolled force simulation (no external libs) -----------------------
+let alpha=1;
+function tick(){
+  for(let i=0;i<nodes.length;i++){ // pairwise repulsion (fine for <=200 nodes)
+    const a=nodes[i];
+    for(let j=i+1;j<nodes.length;j++){
+      const b=nodes[j];
+      let dx=b.x-a.x,dy=b.y-a.y,d2=dx*dx+dy*dy||1,d=Math.sqrt(d2);
+      const f=Math.min(2200/d2,4)*alpha;
+      dx/=d;dy/=d; a.vx-=dx*f;a.vy-=dy*f; b.vx+=dx*f;b.vy+=dy*f;
+    }
+    a.vx+=(W/2-a.x)*0.0018*alpha; a.vy+=(H/2-a.y)*0.0018*alpha; // centering
+  }
+  links.forEach(l=>{ // springs
+    let dx=l.t.x-l.s.x,dy=l.t.y-l.s.y,d=Math.sqrt(dx*dx+dy*dy)||1;
+    const f=(d-95)*0.012*alpha; dx/=d;dy/=d;
+    l.s.vx+=dx*f*d*0.02;l.s.vy+=dy*f*d*0.02;
+    l.t.vx-=dx*f*d*0.02;l.t.vy-=dy*f*d*0.02;
+  });
+  nodes.forEach(n=>{
+    if(n.fixed)return;
+    n.vx*=0.82;n.vy*=0.82; n.x+=n.vx;n.y+=n.vy;
+  });
+  alpha*=0.985;
+  render();
+  if(alpha>0.005)requestAnimationFrame(tick);
+}
+
+// ---- render ----------------------------------------------------------------
+const eEls=links.map(l=>el("line",{stroke:l.color||"#30363d","stroke-opacity":0.4,"stroke-width":1.2},gE));
+const tEls=tlinks.map(l=>{
+  const p=el("path",{fill:"none",stroke:"#f87171","stroke-width":1.6,
+    "stroke-dasharray":"6 4","stroke-opacity":0.85,"marker-end":"url(#arr)"},gT);
+  p.dataset.trid=l.tr.id; return p;
+});
+const nEls=nodes.map(n=>{
+  const g=el("g",{cursor:"pointer"},gN);
+  const inactive=INACTIVE.has(n.status);
+  const isActiveDecision=n.type==="decision"&&!inactive;
+  if(isActiveDecision) // glow ring on ACTIVE decisions — the current truth
+    el("circle",{r:(n.size||10)+5,fill:"none",stroke:COLOR[n.type]||"#8b949e",
+      "stroke-opacity":0.5,"stroke-width":2},g);
+  const c=el("circle",{r:n.size||10,fill:COLOR[n.type]||"#8b949e",
+    "fill-opacity":inactive?0.22:(n.opacity??0.92)},g);
+  if(inactive) // dashed ring marks dead branches — visually distinct, not just faded
+    el("circle",{r:(n.size||10)+3,fill:"none",stroke:"#8b949e",
+      "stroke-dasharray":"3 3","stroke-opacity":0.55,"stroke-width":1},g);
+  if(n.status==="invalidated")
+    el("circle",{r:(n.size||10)+3,fill:"none",stroke:"#f87171",
+      "stroke-dasharray":"2 2","stroke-width":1.4},g);
+  const lbl=el("text",{dx:(n.size||10)+5,dy:4,fill:inactive?"#6e7681":"#c9d1d9",
+    "font-size":11,"paint-order":"stroke",stroke:"#0d1117","stroke-width":3},g);
+  lbl.textContent=n.label.length>34?n.label.slice(0,32)+"\\u2026":n.label;
+  if(inactive)lbl.setAttribute("text-decoration","line-through");
+  g._n=n; n._el=g;
+  // drag
+  let drag=false;
+  g.addEventListener("pointerdown",ev=>{drag=true;n.fixed=true;g.setPointerCapture(ev.pointerId);ev.stopPropagation()});
+  g.addEventListener("pointermove",ev=>{if(!drag)return;
+    const m=pt(ev);n.x=m.x;n.y=m.y;alpha=Math.max(alpha,0.08);
+    if(alpha<=0.09)requestAnimationFrame(tick);render()});
+  g.addEventListener("pointerup",()=>{drag=false;n.fixed=false});
+  // tooltip
+  g.addEventListener("pointerenter",ev=>{
+    tip.style.display="block";
+    tip.innerHTML="<b>"+esc(n.label)+"</b><br><span class='st'>"+n.type+" &middot; "+n.status+
+      "</span>"+(n.summary?"<br>"+esc(n.summary):"")+
+      "<br><span style='color:#484f58'>importance "+n.importance+" &middot; confidence "+n.confidence+"</span>";
+  });
+  g.addEventListener("pointermove",ev=>{tip.style.left=(ev.clientX+14)+"px";tip.style.top=(ev.clientY+10)+"px"});
+  g.addEventListener("pointerleave",()=>tip.style.display="none");
+  return g;
+});
+function render(){
+  links.forEach((l,i)=>{const e=eEls[i];
+    e.setAttribute("x1",l.s.x);e.setAttribute("y1",l.s.y);
+    e.setAttribute("x2",l.t.x);e.setAttribute("y2",l.t.y)});
+  tlinks.forEach((l,i)=>{
+    const mx=(l.s.x+l.t.x)/2, my=(l.s.y+l.t.y)/2;
+    const dx=l.t.x-l.s.x, dy=l.t.y-l.s.y, d=Math.sqrt(dx*dx+dy*dy)||1;
+    tEls[i].setAttribute("d","M"+l.s.x+","+l.s.y+" Q"+(mx-dy/d*40)+","+(my+dx/d*40)+" "+l.t.x+","+l.t.y)});
+  nodes.forEach(n=>n._el.setAttribute("transform","translate("+n.x+","+n.y+")"));
+}
+
+// ---- zoom / pan ------------------------------------------------------------
+let z={k:1,x:0,y:0};
+function applyZ(){vp.setAttribute("transform","translate("+z.x+","+z.y+") scale("+z.k+")")}
+function pt(ev){const r=svg.getBoundingClientRect();
+  return {x:(ev.clientX-r.left-z.x)/z.k, y:(ev.clientY-r.top-z.y)/z.k}}
+svg.addEventListener("wheel",ev=>{ev.preventDefault();
+  const s=ev.deltaY<0?1.15:0.87, nk=Math.min(4,Math.max(0.2,z.k*s));
+  const r=svg.getBoundingClientRect(),mx=ev.clientX-r.left,my=ev.clientY-r.top;
+  z.x=mx-(mx-z.x)*(nk/z.k); z.y=my-(my-z.y)*(nk/z.k); z.k=nk; applyZ();
+},{passive:false});
+let panning=false,px=0,py=0;
+svg.addEventListener("pointerdown",ev=>{if(ev.target===svg||ev.target===vp){panning=true;px=ev.clientX;py=ev.clientY}});
+addEventListener("pointermove",ev=>{if(!panning)return;
+  z.x+=ev.clientX-px;z.y+=ev.clientY-py;px=ev.clientX;py=ev.clientY;applyZ()});
+addEventListener("pointerup",()=>panning=false);
+
+// ---- filters ---------------------------------------------------------------
+const hidden=new Set(); let activeOnly=false, q="";
+function visible(n){
+  if(hidden.has(n.type))return false;
+  if(activeOnly&&INACTIVE.has(n.status))return false;
+  return true;
+}
+function applyFilters(){
+  nodes.forEach(n=>{
+    const v=visible(n);
+    const match=!q||n.label.toLowerCase().includes(q)||(n.summary||"").toLowerCase().includes(q);
+    n._el.style.display=v?"":"none";
+    n._el.style.opacity=match?1:0.12;
+  });
+  links.forEach((l,i)=>eEls[i].style.display=(visible(l.s)&&visible(l.t))?"":"none");
+  tlinks.forEach((l,i)=>tEls[i].style.display=(visible(l.s)&&visible(l.t))?"":"none");
+}
+const chips=document.getElementById("chips");
+types.forEach(t=>{
+  const c=document.createElement("span");c.className="chip";
+  c.innerHTML="<i style='background:"+(COLOR[t]||"#8b949e")+"'></i>"+t;
+  c.onclick=()=>{hidden.has(t)?hidden.delete(t):hidden.add(t);
+    c.classList.toggle("off",hidden.has(t));applyFilters()};
+  chips.appendChild(c);
+});
+document.getElementById("activeOnly").onclick=function(){
+  activeOnly=!activeOnly;this.classList.toggle("on",activeOnly);applyFilters()};
+document.getElementById("search").addEventListener("input",function(){
+  q=this.value.trim().toLowerCase();applyFilters()});
+document.getElementById("reheat").onclick=()=>{alpha=1;requestAnimationFrame(tick)};
+
+// ---- decision-history timeline ----------------------------------------------
+const trList=document.getElementById("trList");
+function esc(s){return String(s).replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]))}
+if(!trans.length){
+  trList.innerHTML="<div class='empty'>No decision changes yet.<br>When a decision is superseded, the old&#8594;new story appears here.</div>";
+}else{
+  [...trans].sort((a,b)=>(b.timestamp||0)-(a.timestamp||0)).forEach(t=>{
+    const d=document.createElement("div");d.className="tr-item";
+    const when=t.timestamp?new Date(t.timestamp*1000).toLocaleString():"";
+    d.innerHTML="<span class='old'>"+esc(t.from_label)+"</span><span class='arrow'>&#8594;</span>"+
+      "<span class='new'>"+esc(t.to_label)+"</span>"+
+      (t.reason?"<div class='why'>"+esc(t.reason)+"</div>":"")+
+      "<div class='meta'>"+esc(t.trigger||"superseded")+(when?" &middot; "+when:"")+"</div>";
+    d.onclick=()=>{
+      document.querySelectorAll(".tr-item.sel").forEach(x=>x.classList.remove("sel"));
+      d.classList.add("sel");
+      const a=byId[t.from_id],b=byId[t.to_id];
+      nodes.forEach(n=>n._el.style.opacity=(n===a||n===b)?1:0.12);
+      if(b){ // center the view on the new decision
+        z.x=W/2-b.x*z.k; z.y=H/2-b.y*z.k; applyZ();
+      }
+    };
+    trList.appendChild(d);
+  });
+}
+document.addEventListener("keydown",e=>{if(e.key==="Escape"){
+  document.querySelectorAll(".tr-item.sel").forEach(x=>x.classList.remove("sel"));
+  q="";document.getElementById("search").value="";applyFilters()}});
+
+// ---- PNG export --------------------------------------------------------------
+document.getElementById("exportPng").onclick=()=>{
+  const clone=svg.cloneNode(true);
+  clone.setAttribute("xmlns",NS);
+  const bg=document.createElementNS(NS,"rect");
+  bg.setAttribute("width","100%");bg.setAttribute("height","100%");bg.setAttribute("fill","#0d1117");
+  clone.insertBefore(bg,clone.firstChild);
+  const blob=new Blob([new XMLSerializer().serializeToString(clone)],{type:"image/svg+xml"});
+  const url=URL.createObjectURL(blob), img=new Image();
+  img.onload=()=>{
+    const cv=document.createElement("canvas");cv.width=W*2;cv.height=H*2;
+    const ctx=cv.getContext("2d");ctx.scale(2,2);ctx.drawImage(img,0,0);
+    URL.revokeObjectURL(url);
+    const a=document.createElement("a");
+    a.download="tokenmizer-__SESSION__.png";a.href=cv.toDataURL("image/png");a.click();
+  };
+  img.src=url;
+};
+
+render();applyFilters();requestAnimationFrame(tick);
 </script></body></html>
 """
 
 
 def to_share_html(graph: "GraphMemory") -> str:
-    """Self-contained dark interactive force-graph HTML — open in any
-    browser, drag/zoom, screenshot, share. The viral artifact."""
+    """Self-contained dark interactive graph HTML — open in any browser,
+    zero network dependencies (works offline / air-gapped demo).
+
+    What it shows that a generic graph view doesn't:
+      - decision supersession arcs (old → new, dashed red, arrowhead)
+      - a clickable "Decision history" timeline panel (old label struck
+        through → new label, with trigger + reason + timestamp); clicking
+        an entry spotlights the two nodes and centers the view
+      - active decisions get a glow ring; superseded/archived get a dashed
+        ring + strikethrough label; invalidated get a red dashed ring
+      - per-type filter chips, "Active only" toggle, text search,
+        wheel-zoom/pan, and one-click PNG export
+    """
     import json as _json
 
     vis = graph.to_vis_json()
     nodes = vis.get("nodes", [])
     edges = vis.get("edges", [])
-    # d3.forceLink needs source/target keys
-    for e in edges:
-        e.setdefault("source", e.get("from") or e.get("source_id"))
-        e.setdefault("target", e.get("to") or e.get("target_id"))
+    transitions = vis.get("transitions", [])
     decisions = sum(1 for n in nodes if n.get("type") == "decision")
     html = (_SHARE_HTML_TEMPLATE
             .replace("__SESSION__", graph.session_id)
             .replace("__NODES__", str(len(nodes)))
             .replace("__EDGES__", str(len(edges)))
             .replace("__DECISIONS__", str(decisions))
-            .replace("__DATA__", _json.dumps({"nodes": nodes, "edges": edges}))
+            .replace("__TRANSITIONS__", str(len(transitions)))
+            .replace("__DATA__", _json.dumps({
+                "nodes": nodes, "edges": edges, "transitions": transitions,
+            }))
             .replace("__COLORS__", _json.dumps(_TYPE_COLOR)))
     return html

--- a/tokenmizer/mcp/server.py
+++ b/tokenmizer/mcp/server.py
@@ -183,27 +183,52 @@ def _post(path: str, body: dict) -> dict:
 
 
 # ── Tool handlers ─────────────────────────────────────────────────────────────
+#
+# Every handler returns (text, is_error). AUDIT FIX (2026-07-10): previously
+# handlers returned bare strings and the transport decided isError by checking
+# result_text.startswith("❌") — so a KeyError from a missing required argument
+# surfaced as "Tool error: 'session_id'" with isError: FALSE, i.e. reported to
+# MCP clients as a *successful* tool result. isError is now structural.
 
-def handle_checkpoint_session(args: dict) -> str:
-    session_id = args["session_id"]
+
+class ToolInputError(ValueError):
+    """Client sent arguments that fail the tool's declared inputSchema."""
+
+
+def _require_str(args: dict, key: str) -> str:
+    val = args.get(key)
+    if not isinstance(val, str) or not val.strip():
+        raise ToolInputError(
+            f"Missing or invalid required argument '{key}' (expected a "
+            f"non-empty string, got {type(val).__name__}: {val!r})"
+        )
+    return val
+
+
+def handle_checkpoint_session(args: dict) -> tuple[str, bool]:
+    session_id = _require_str(args, "session_id")
     result = _post(f"/api/checkpoint?session_id={session_id}", {})
     if "error" in result:
-        return f"❌ Checkpoint failed: {result['error']}"
+        return f"❌ Checkpoint failed: {result['error']}", True
     return (
         f"✅ Session '{session_id}' checkpointed\n"
         f"Checkpoint ID: {result.get('checkpoint_id', 'unknown')}\n"
         f"Nodes in graph: {result.get('node_count', 0)}\n"
         f"Resume size: {result.get('resume_tokens', 0)} tokens\n\n"
         f"Resume context:\n{result.get('resume_standard', '')}"
-    )
+    ), False
 
 
-def handle_resume_session(args: dict) -> str:
-    session_id = args["session_id"]
+def handle_resume_session(args: dict) -> tuple[str, bool]:
+    session_id = _require_str(args, "session_id")
     level = args.get("level", "standard")
+    if level not in ("critical", "standard", "full"):
+        raise ToolInputError(
+            f"Invalid 'level': {level!r} (expected critical|standard|full)"
+        )
     result = _get(f"/api/resume/{session_id}?level={level}")
     if "error" in result:
-        return f"❌ Resume failed: {result['error']}"
+        return f"❌ Resume failed: {result['error']}", True
     ctx = result.get("resume_context", "")
     tokens = result.get("token_count", 0)
     if not ctx:
@@ -216,19 +241,19 @@ def handle_resume_session(args: dict) -> str:
             f"'{session_id}' but its graph was empty (no session activity "
             f"had been recorded when it was created). Chat through the proxy "
             f"with this session_id, then checkpoint again."
-        )
+        ), False
     return (
         f"[TokenMizer Resume — session: {session_id} — {tokens} tokens]\n\n"
         f"{ctx}\n\n"
         f"[Paste the above into your system prompt to resume this session]"
-    )
+    ), False
 
 
-def handle_get_graph_stats(args: dict) -> str:
-    session_id = args["session_id"]
+def handle_get_graph_stats(args: dict) -> tuple[str, bool]:
+    session_id = _require_str(args, "session_id")
     result = _get(f"/api/graph/{session_id}")
     if "error" in result:
-        return f"❌ Graph stats failed: {result['error']}"
+        return f"❌ Graph stats failed: {result['error']}", True
     by_type = result.get("by_type", {})
     by_status = result.get("by_status", {})
     lines = [
@@ -244,19 +269,26 @@ def handle_get_graph_stats(args: dict) -> str:
     lines.append("\nNode statuses:")
     for s, count in sorted(by_status.items()):
         lines.append(f"  {s}: {count}")
-    return "\n".join(lines)
+    return "\n".join(lines), False
 
 
-def handle_analyze_file(args: dict) -> str:
-    file_path = args["file_path"]
+def handle_analyze_file(args: dict) -> tuple[str, bool]:
+    file_path = _require_str(args, "file_path")
     token_budget = args.get("token_budget", 500)
+    if not isinstance(token_budget, int) or isinstance(token_budget, bool) \
+            or token_budget <= 0:
+        raise ToolInputError(
+            f"Invalid 'token_budget': {token_budget!r} (expected a positive integer)"
+        )
     query = args.get("query", "")
+    if not isinstance(query, str):
+        raise ToolInputError(f"Invalid 'query': expected string, got {type(query).__name__}")
 
     try:
         from pathlib import Path
         path = Path(file_path)
         if not path.exists():
-            return f"❌ File not found: {file_path}"
+            return f"❌ File not found: {file_path}", True
 
         content = path.read_bytes()
         from tokenmizer.filters.file_intelligence import FileIntelligence
@@ -269,15 +301,16 @@ def handle_analyze_file(args: dict) -> str:
             f"Extracted: {result.extracted_tokens} tokens | "
             f"Saved: {result.savings_pct:.0f}%\n\n"
             f"{result.content}"
-        )
+        ), False
     except Exception as e:
-        return f"❌ File analysis error: {e}"
+        logger.warning(f"analyze_file failed for {file_path}: {type(e).__name__}: {e}")
+        return f"❌ File analysis error: {type(e).__name__}: {e}", True
 
 
-def handle_get_savings_stats(args: dict) -> str:
+def handle_get_savings_stats(args: dict) -> tuple[str, bool]:
     result = _get("/api/stats")
     if "error" in result:
-        return f"❌ Stats failed: {result['error']}"
+        return f"❌ Stats failed: {result['error']}", True
     d = result.get("daily", {})
     w = result.get("weekly", {})
     breakdown = result.get("layer_breakdown", {})
@@ -293,12 +326,13 @@ def handle_get_savings_stats(args: dict) -> str:
     ]
     for layer, saved in sorted(breakdown.items()):
         lines.append(f"  {layer}: {saved:,} tokens")
-    return "\n".join(lines)
+    return "\n".join(lines), False
 
 
 # ── MCP stdio transport ───────────────────────────────────────────────────────
 
-def handle_tool_call(name: str, arguments: dict) -> str:
+def handle_tool_call(name: str, arguments: Any) -> tuple[str, bool]:
+    """Dispatch a tools/call. Returns (text, is_error) — never raises."""
     handlers = {
         "checkpoint_session": handle_checkpoint_session,
         "resume_session": handle_resume_session,
@@ -308,18 +342,87 @@ def handle_tool_call(name: str, arguments: dict) -> str:
     }
     handler = handlers.get(name)
     if not handler:
-        return f"Unknown tool: {name}"
+        # AUDIT FIX: was reported with isError false (looked like success).
+        return f"Unknown tool: {name!r}. Available: {sorted(handlers)}", True
+    if not isinstance(arguments, dict):
+        return (
+            f"Invalid arguments for tool '{name}': expected a JSON object, "
+            f"got {type(arguments).__name__}"
+        ), True
     try:
         return handler(arguments)
+    except ToolInputError as e:
+        logger.warning(f"Tool '{name}' rejected input: {e}")
+        return f"Invalid input for tool '{name}': {e}", True
     except Exception as e:
-        return f"Tool error: {e}"
+        logger.exception(f"Tool '{name}' crashed")
+        return f"Tool '{name}' internal error: {type(e).__name__}: {e}", True
+
+
+def _handle_request(req: dict, send) -> None:
+    """Handle one parsed JSON-RPC request object."""
+    req_id = req.get("id")
+    method = req.get("method", "")
+    params = req.get("params") if isinstance(req.get("params"), dict) else {}
+    is_notification = "id" not in req
+
+    if method == "initialize":
+        from tokenmizer import __version__
+        send({
+            "jsonrpc": "2.0", "id": req_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "tokenmizer", "version": __version__},
+            },
+        })
+
+    elif method == "tools/list":
+        send({"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}})
+
+    elif method == "tools/call":
+        tool_name = params.get("name", "")
+        arguments = params.get("arguments", {})
+        result_text, is_error = handle_tool_call(tool_name, arguments)
+        send({
+            "jsonrpc": "2.0", "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": result_text}],
+                "isError": is_error,
+            },
+        })
+
+    elif method.startswith("notifications/"):
+        pass  # notifications never get a response
+
+    elif not is_notification:
+        send({"jsonrpc": "2.0", "id": req_id,
+              "error": {"code": -32601, "message": f"Method not found: {method}"}})
 
 
 def run_stdio_server():
     """
     MCP stdio transport — reads JSON-RPC from stdin, writes to stdout.
-    This is the standard MCP server protocol.
+    Newline-delimited JSON framing (one object per line, both directions).
+
+    AUDIT FIX (2026-07-10): the previous loop had three ways to die or
+    go dark with zero diagnostics:
+      1. any exception inside a handler outside tools/call (e.g. a broken
+         `initialize` import) crashed the whole process — the client hung
+         waiting for a reply, then saw the subprocess exit;
+      2. a valid-JSON-but-not-an-object line ([1,2], "hi") raised
+         AttributeError on req.get() — same crash;
+      3. malformed JSON lines were silently discarded (`continue`, no log,
+         no JSON-RPC error) — the client's request hung forever.
+    Logging goes to STDERR (stdout is the protocol channel); every failure
+    now produces both a log line and, where a request id exists, a
+    JSON-RPC error response.
     """
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=os.environ.get("TOKENMIZER_MCP_LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s tokenmizer-mcp: %(message)s",
+    )
 
     def send(obj: dict):
         sys.stdout.write(json.dumps(obj) + "\n")
@@ -328,50 +431,41 @@ def run_stdio_server():
     def send_error(req_id: Any, code: int, message: str):
         send({"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}})
 
+    logger.info(f"tokenmizer MCP stdio server started (proxy: {TOKENMIZER_URL})")
+
     for line in sys.stdin:
         line = line.strip()
         if not line:
             continue
         try:
             req = json.loads(line)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            logger.warning(f"Dropping malformed JSON line ({e}): {line[:200]!r}")
+            send_error(None, -32700, f"Parse error: {e}")
             continue
 
-        req_id = req.get("id")
-        method = req.get("method", "")
-        params = req.get("params", {})
+        if not isinstance(req, dict):
+            logger.warning(f"Dropping non-object JSON-RPC message: {line[:200]!r}")
+            send_error(None, -32600, "Invalid request: expected a JSON object")
+            continue
 
-        if method == "initialize":
-            from tokenmizer import __version__
-            send({
-                "jsonrpc": "2.0", "id": req_id,
-                "result": {
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {"tools": {}},
-                    "serverInfo": {"name": "tokenmizer", "version": __version__},
-                },
-            })
+        try:
+            _handle_request(req, send)
+        except (BrokenPipeError, OSError):
+            # stdout is gone — client disconnected mid-write; nothing left
+            # to reply to. Exit the loop cleanly.
+            logger.info("Client disconnected (broken pipe); shutting down")
+            return
+        except Exception as e:
+            logger.exception(f"Unhandled error in method {req.get('method')!r}")
+            try:
+                send_error(req.get("id"), -32603,
+                           f"Internal error: {type(e).__name__}: {e}")
+            except Exception:
+                logger.error("Could not send error response; shutting down")
+                return
 
-        elif method == "tools/list":
-            send({"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}})
-
-        elif method == "tools/call":
-            tool_name = params.get("name", "")
-            arguments = params.get("arguments", {})
-            result_text = handle_tool_call(tool_name, arguments)
-            send({
-                "jsonrpc": "2.0", "id": req_id,
-                "result": {
-                    "content": [{"type": "text", "text": result_text}],
-                    "isError": result_text.startswith("❌"),
-                },
-            })
-
-        elif method == "notifications/initialized":
-            pass  # acknowledge, no response needed
-
-        else:
-            send_error(req_id, -32601, f"Method not found: {method}")
+    logger.info("stdin closed; MCP server exiting")
 
 
 if __name__ == "__main__":

--- a/tokenmizer/security/redaction.py
+++ b/tokenmizer/security/redaction.py
@@ -49,6 +49,27 @@ _PATTERNS = [
         r'["\']?[\w\-\.\/+]{8,}',
         re.IGNORECASE,
     ),
+    # AUDIT FIX (2026-07-10): URL-embedded credentials — a DATABASE_URL like
+    # postgres://admin:S3cr3tPass@db.internal:5432/prod carried a live
+    # password that matched NO pattern above (no "password=" literal, no
+    # recognized token prefix). Redact the userinfo section of any URL that
+    # has one. Only the credential part is replaced; scheme/host survive so
+    # the message stays readable.
+    re.compile(r'(?<=://)[^\s/:@]+:[^\s/@]+(?=@)'),
+    # AUDIT FIX (2026-07-10): provider key formats that were missing —
+    # best-effort, documented as such (providers rotate formats):
+    # Cohere trial/prod keys are 40 alnum chars bound to a "co-" style
+    # context we can't anchor on, so we rely on the generic key=... rule
+    # for those; the below are the anchorable ones.
+    # xAI / Grok
+    re.compile(r'xai-[A-Za-z0-9]{20,}'),
+    # OpenRouter
+    re.compile(r'sk-or-[A-Za-z0-9\-_]{20,}', re.IGNORECASE),
+    # Hugging Face
+    re.compile(r'hf_[A-Za-z0-9]{30,}'),
+    # Together AI (64 hex chars after explicit assignment handled by generic
+    # rule; standalone "together_" prefixed keys:)
+    re.compile(r'together_[A-Za-z0-9]{20,}', re.IGNORECASE),
     # Email addresses (PII)
     re.compile(r'\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Z|a-z]{2,}\b'),
 ]


### PR DESCRIPTION
## Summary

Full audit + fix pass across the whole repo (graph memory, MCP server, silent failures, security, visualization). **220 → 280 tests, all green; ruff clean; `scripts/mcp_e2e_check.py` ALL PASS.** Complete details in the `[0.3.2]` CHANGELOG entry.

### Critical
- **The LLM extraction path never worked once.** `api/app.py` called `HybridExtractor(provider_fn=_pfn)` — a kwarg `__init__` never accepted — so every call raised `TypeError`, was caught, and logged as a transient provider failure. Even fixed, `extract()` was called without `provider_fn`, skipping the LLM pass. `use_llm_extraction: true` has been a no-op since it shipped. Fixed + regression test.

### Graph memory
- Topic classifier: "Go"-verb/Go-language collision, vocabulary drift (supabase/clerk/…), multi-topic decisions now return ALL topics with set-intersection contradiction detection
- `ARCHIVED` was advertised but unreachable — superseded decisions now age into it after 7 days
- Near-duplicate decisions from one message merge instead of self-superseding
- Validator blends extractor corroboration confidence; `min_confidence` no longer dead code
- `/api/decision/invalidate` no longer destroys SUPERSEDED history

### MCP server
- `isError` was `startswith("❌")` string-sniffing — missing required args were reported to clients as **successful** results. Now structural.
- Three server-killer inputs fixed (initialize crash, non-object JSON, silently dropped malformed lines) — all now proper JSON-RPC errors, loop survives
- `logger` was dead code; stderr logging wired (`TOKENMIZER_MCP_LOG_LEVEL`)
- Input validation on all tools; 18 new unit tests

### Security
- Redaction: URL-embedded credentials (`postgres://user:pass@host`), OpenRouter/HF/xAI patterns, defense-in-depth at the checkpoint layer

### Visualization
- Rewritten: zero external deps (no D3 CDN — works offline), supersession arcs, clickable decision-history timeline, type/status filters, search, zoom/pan, PNG export. Verified in a real browser via DOM inspection.

### CI / release
- Windows CI leg (audit found 3 Windows-only bugs: cp1252 CLI crash, WinError 32 handle leak) + CLI smoke test + MCP e2e step
- Version-consistency tests (`server.json` was 3 releases stale, `plugin.json` 4)
- `release.yml` verifies tag matches package version
- Version bumped to **0.3.2** everywhere

### Docs
- README truth-pass (every quick-start command dry-run), `docs/DEMO_SCRIPT.md` demo storyboard

## Test plan
- [x] `pytest tests/` — 280 passed
- [x] `ruff check tokenmizer/ tests/` — clean
- [x] `python scripts/mcp_e2e_check.py` — ALL PASS
- [x] Visualization exercised in a real browser (filters, search, timeline spotlight)
- [x] README quick start dry-run (`serve`, `/health`, dashboard, checkpoint, resume, MCP from stdio)
- [ ] CI green on this PR (including the new Windows leg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)