### PR TITLE
fix: derive graph node ids from stored labels

### DIFF
--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -46,6 +46,16 @@ class TestNodeDeduplication:
         graph.add_node(NodeType.TASK, "Implement auth", NodeStatus.PENDING)
         assert graph._nodes[id1].status == NodeStatus.COMPLETED
 
+    def test_labels_identical_after_truncation_share_node_id(self, graph):
+        label = "Implement authentication " + "A" * 150
+
+        id1 = graph.add_node(NodeType.TASK, label)
+        id2 = graph.add_node(NodeType.TASK, label[:120])
+
+        assert id1 == id2
+        assert len(graph._nodes) == 1
+        assert graph._nodes[id1].label == label[:120]
+
 
 class TestNodeTypes:
 

--- a/tokenmizer/graph_memory/graph.py
+++ b/tokenmizer/graph_memory/graph.py
@@ -415,6 +415,7 @@ class GraphMemory:
         label, summary = redact_node(label, summary)
 
         stored_label = label[:120]
+        stored_summary = summary[:300]
         norm = self._normalize_label(stored_label)
         node_id = self._node_id(node_type.value, norm)
 
@@ -436,8 +437,8 @@ class GraphMemory:
             }
             if status_rank.get(status, 0) > status_rank.get(existing.status, 0):
                 existing.status = status
-            if summary and not existing.summary:
-                existing.summary = summary
+            if stored_summary and not existing.summary:
+                existing.summary = stored_summary
             return node_id
 
         # Fuzzy same-decision merge. Exact-hash dedup above only catches
@@ -464,10 +465,10 @@ class GraphMemory:
                     }
                     if _rank.get(status, 0) > _rank.get(ex.status, 0):
                         ex.status = status
-                    if len(label) > len(ex.label) and status == ex.status:
-                        ex.label = label[:120]
-                    if summary and not ex.summary:
-                        ex.summary = summary[:300]
+                    if len(stored_label) > len(ex.label) and status == ex.status:
+                        ex.label = stored_label
+                    if stored_summary and not ex.summary:
+                        ex.summary = stored_summary
                     return ex_id
 
         # Validate before inserting — reject noise and low-confidence nodes.
@@ -499,7 +500,7 @@ class GraphMemory:
             type=node_type,
             label=stored_label,
             status=status,
-            summary=summary[:300],
+            summary=stored_summary,
             importance=importance,
             confidence=confidence if confidence != 0.7 else result.confidence,
         )

--- a/tokenmizer/graph_memory/graph.py
+++ b/tokenmizer/graph_memory/graph.py
@@ -414,7 +414,8 @@ class GraphMemory:
         from tokenmizer.security.redaction import redact_node
         label, summary = redact_node(label, summary)
 
-        norm = self._normalize_label(label)
+        stored_label = label[:120]
+        norm = self._normalize_label(stored_label)
         node_id = self._node_id(node_type.value, norm)
 
         if node_id in self._nodes:
@@ -496,7 +497,7 @@ class GraphMemory:
         node = MemoryNode(
             id=node_id,
             type=node_type,
-            label=label[:120],
+            label=stored_label,
             status=status,
             summary=summary[:300],
             importance=importance,


### PR DESCRIPTION
Fixes #20

## Summary
- derive graph node IDs from the same 120-character label representation stored on `MemoryNode`
- add a regression test for long labels that become identical after truncation

## Validation
- `python3 -m pytest tests/unit/test_graph.py -q`
- `python3 -m pytest tests/unit -q`
- exact reproduction now returns one ID and one node
- `git diff --check`
- `rg -n "Karim13014|claude-code@anthropic.com" . -g '!.git'`
