### PR TITLE
Handle negated decisions during decision deduplication

### DIFF
--- a/tests/unit/test_decision_tracker.py
+++ b/tests/unit/test_decision_tracker.py
@@ -156,11 +156,10 @@ def test_containment_needs_two_words():
     assert not _is_same_decision("PostgreSQL", "Switch from PostgreSQL to SQLite")
     assert not _is_same_decision("Use PostgreSQL", "Switch from PostgreSQL to SQLite")
     assert _is_same_decision("Use React", "use React for the frontend.")
-    assert not _is_same_decision("Use PostgreSQL", "Do not use PostgreSQL")
-    assert not _is_same_decision("Enable caching", "Disable caching")
-    assert not _is_same_decision("Use Redis", "Avoid Redis")
+    assert not _is_same_decision("Use PostgreSQL", "Do not use PostgreSQL",)
+    assert _is_same_decision("Do not use Redis", "do not use Redis for caching",)
 
-   
+
 def test_real_supersession_still_fires_after_merge_fix(tmp_path):
     """The merge fix must not swallow genuine contradictions."""
     g = GraphMemory(session_id="t-dup4", storage_dir=str(tmp_path))

--- a/tests/unit/test_decision_tracker.py
+++ b/tests/unit/test_decision_tracker.py
@@ -156,8 +156,11 @@ def test_containment_needs_two_words():
     assert not _is_same_decision("PostgreSQL", "Switch from PostgreSQL to SQLite")
     assert not _is_same_decision("Use PostgreSQL", "Switch from PostgreSQL to SQLite")
     assert _is_same_decision("Use React", "use React for the frontend.")
+    assert not _is_same_decision("Use PostgreSQL", "Do not use PostgreSQL")
+    assert not _is_same_decision("Enable caching", "Disable caching")
+    assert not _is_same_decision("Use Redis", "Avoid Redis")
 
-
+   
 def test_real_supersession_still_fires_after_merge_fix(tmp_path):
     """The merge fix must not swallow genuine contradictions."""
     g = GraphMemory(session_id="t-dup4", storage_dir=str(tmp_path))

--- a/tokenmizer/graph_memory/decision_tracker.py
+++ b/tokenmizer/graph_memory/decision_tracker.py
@@ -269,6 +269,7 @@ def _find_by_word_overlap(
 
 def _is_same_decision(label_a: str, label_b: str) -> bool:
     """True if two labels are essentially the same decision (dedup check)."""
+
     def _norm(s: str) -> str:
         s = s.lower().rstrip(".,!?;:")
         # Normalize common tech name variants
@@ -278,12 +279,32 @@ def _is_same_decision(label_a: str, label_b: str) -> bool:
         return re.sub(r"\s+", " ", s).strip()
 
     a, b = _norm(label_a), _norm(label_b)
+
     if a == b:
         return True
+
     words_a = set(a.split())
     words_b = set(b.split())
+
     if not words_a or not words_b:
         return False
+
+    NEGATIONS = {
+        "not",
+        "no",
+        "never",
+        "dont",
+        "don't",
+    }
+
+    neg_a = bool(words_a & NEGATIONS)
+    neg_b = bool(words_b & NEGATIONS)
+
+    # Don't merge decisions if one is negated and the other isn't.
+    if neg_a != neg_b:
+        return False
+
+
     # Containment: "Use React" and "use React for the frontend." are the
     # same decision even though flat word overlap (2/5) is far below the
     # threshold. The extractor can emit both variants from one message.
@@ -293,4 +314,4 @@ def _is_same_decision(label_a: str, label_b: str) -> bool:
     if len(smaller) >= 2 and smaller <= larger:
         return True
     overlap = len(words_a & words_b) / max(len(words_a), len(words_b))
-    return overlap >= 0.82
+    return overlap >=   0.82


### PR DESCRIPTION
## Summary

This PR fixes #19 by preventing `_is_same_decision()` from treating negated decisions as equivalent during decision deduplication.

### Example

Previously:

- Use PostgreSQL
- Do not use PostgreSQL

were considered the same decision and merged into a single node.

With this change, decisions with different negation state are no longer considered equivalent, allowing them to be tracked separately.

## Tests

- Added a regression test covering negated decisions.
- Existing decision tracker tests continue to pass.
- Full test suite passes locally.

Fixes #19