### PR TITLE
Align OutputTrimmer levels with configuration

### DIFF
--- a/tests/unit/test_file_intelligence.py
+++ b/tests/unit/test_file_intelligence.py
@@ -285,6 +285,22 @@ class TestOutputTrimmer:
         assert trimmed == ""
         assert saved == 0
 
+    def test_full_level_removes_closing_fillers(self):
+        from tokenmizer.compression.output_trimmer import OutputTrimmer
+
+        t = OutputTrimmer()
+
+        text = (
+            "Certainly!\n\n"
+            "Here is your answer.\n\n"
+            "Hope this helps!"
+        )
+
+        trimmed, saved = t.trim(text, "full")
+
+        assert "Hope this helps!" not in trimmed
+        assert saved > 0
+
 
 # ── Smart window ──────────────────────────────────────────────────────────────
 

--- a/tokenmizer/compression/output_trimmer.py
+++ b/tokenmizer/compression/output_trimmer.py
@@ -55,13 +55,13 @@ _INLINE_REDUNDANCIES = [
 
 class OutputTrimmer:
 
-    def trim(self, text: str, level: str = "standard") -> tuple[str, int]:
+    def trim(self, text: str, level: str = "full") -> tuple[str, int]:
         """
         Remove structural filler from LLM output.
 
         Args:
             text: raw LLM response
-            level: "lite" (openings only) | "standard" | "aggressive"
+            level: "lite" (openings only) | "full" | "ultra"
 
         Returns:
             (trimmed_text, tokens_saved)
@@ -76,13 +76,13 @@ class OutputTrimmer:
         for pat in _OPENING_FILLERS:
             result = pat.sub("", result, count=1)
 
-        if level in ("standard", "aggressive"):
+        if level in ("full", "ultra"):
             # Closing fillers
             for pat in _CLOSING_FILLERS:
                 result = pat.sub("", result)
 
-        if level == "aggressive":
-            # Inline redundancies (only on aggressive — risky otherwise)
+        if level == "ultra":
+            # Inline redundancies (only on ultra — risky otherwise)
             for pat in _INLINE_REDUNDANCIES:
                 result = pat.sub("\n\n", result)
 


### PR DESCRIPTION
## Summary

This PR fixes the mismatch between the configured terse output levels and the levels recognized by `OutputTrimmer`.

Fixes #23.

### Changes

- Updated `OutputTrimmer.trim()` to use the `lite` / `full` / `ultra` vocabulary directly.
- Updated the docstring to reflect the supported levels.
- Added a regression test verifying that `"full"` removes closing fillers instead of behaving like `"lite"`.

### Verification

- `ruff check tests/ tokenmizer/`
- `pytest tests/unit/test_file_intelligence.py -v`