### PR TITLE
fix: detect semantic opposite decisions

### DIFF
--- a/tests/unit/test_decision_tracker.py
+++ b/tests/unit/test_decision_tracker.py
@@ -160,6 +160,37 @@ def test_containment_needs_two_words():
     assert _is_same_decision("Do not use Redis", "do not use Redis for caching",)
 
 
+def test_semantic_opposites_are_not_same_decision():
+    from tokenmizer.graph_memory.decision_tracker import _is_same_decision
+
+    assert not _is_same_decision(
+        "Enable JWT auth for the API",
+        "Disable JWT auth for the API",
+    )
+    assert not _is_same_decision("Allow external signups", "Block external signups")
+    assert not _is_same_decision("Use Redis", "Avoid Redis")
+    assert _is_same_decision("Disable caching", "disable caching for the API")
+
+
+def test_semantic_opposite_decisions_are_preserved(tmp_path):
+    g = GraphMemory(session_id="t-semantic-opposites", storage_dir=str(tmp_path))
+
+    enabled_id = g.add_node(
+        NodeType.DECISION,
+        "Enable JWT auth for the API",
+        NodeStatus.COMPLETED,
+    )
+    disabled_id = g.add_node(
+        NodeType.DECISION,
+        "Disable JWT auth for the API",
+        NodeStatus.COMPLETED,
+    )
+
+    assert disabled_id != enabled_id
+    assert g._nodes[enabled_id].status == NodeStatus.SUPERSEDED
+    assert g._nodes[disabled_id].status == NodeStatus.COMPLETED
+
+
 def test_real_supersession_still_fires_after_merge_fix(tmp_path):
     """The merge fix must not swallow genuine contradictions."""
     g = GraphMemory(session_id="t-dup4", storage_dir=str(tmp_path))

--- a/tokenmizer/graph_memory/decision_tracker.py
+++ b/tokenmizer/graph_memory/decision_tracker.py
@@ -289,21 +289,41 @@ def _is_same_decision(label_a: str, label_b: str) -> bool:
     if not words_a or not words_b:
         return False
 
-    NEGATIONS = {
+    negations = {
         "not",
         "no",
         "never",
         "dont",
         "don't",
     }
+    opposite_terms = (
+        ("enable", "disable"),
+        ("enabled", "disabled"),
+        ("allow", "block"),
+        ("allowed", "blocked"),
+        ("permit", "forbid"),
+        ("permitted", "forbidden"),
+        ("use", "avoid"),
+        ("add", "remove"),
+        ("include", "exclude"),
+    )
 
-    neg_a = bool(words_a & NEGATIONS)
-    neg_b = bool(words_b & NEGATIONS)
+    neg_a = bool(words_a & negations)
+    neg_b = bool(words_b & negations)
 
     # Don't merge decisions if one is negated and the other isn't.
     if neg_a != neg_b:
         return False
 
+    for positive, negative in opposite_terms:
+        a_positive = positive in words_a
+        a_negative = negative in words_a
+        b_positive = positive in words_b
+        b_negative = negative in words_b
+        if (a_positive and b_negative and not a_negative and not b_positive) or (
+            a_negative and b_positive and not a_positive and not b_negative
+        ):
+            return False
 
     # Containment: "Use React" and "use React for the frontend." are the
     # same decision even though flat word overlap (2/5) is far below the


### PR DESCRIPTION
Fixes #24

## Summary
- detect semantic opposite verb pairs such as enable/disable, allow/block, and use/avoid before decision deduplication
- keep same-direction variants mergeable, such as repeated disable decisions with extra context
- add regression coverage for direct `_is_same_decision()` behavior and full `GraphMemory.add_node()` preservation/supersession

## Validation
- `python3 -m pytest tests/unit/test_decision_tracker.py -q`
- `python3 -m pytest tests/unit -q`
- `. .venv/bin/activate && ruff check tokenmizer/ tests/`
- `. .venv/bin/activate && pytest tests/ -q`
- `. .venv/bin/activate && pytest tests/ --cov=tokenmizer --cov-report=term-missing --cov-report=xml -q`
- `. .venv/bin/activate && python scripts/mcp_e2e_check.py`
- exact reproduction now returns `False` for `_is_same_decision("Enable JWT auth for the API", "Disable JWT auth for the API")` and preserves two decision nodes
- `git diff --check`
- `rg -n 'Karim13014|claude-code@anthropic.com' . -g '!.git' -g '!.venv' -g '!__pycache__' -g '!.pytest_cache'`