### PR TITLE
Fix cache hit analytics for streaming responses

### DIFF
--- a/tests/integration/test_api_endpoint.py
+++ b/tests/integration/test_api_endpoint.py
@@ -8,6 +8,7 @@ and nothing caught it because no test ever POSTed to the app. These tests
 exercise the real HTTP path so a route-registration regression can never
 ship silently again.
 """
+from time import time
 from unittest.mock import AsyncMock
 
 import pytest
@@ -16,6 +17,7 @@ from fastapi.testclient import TestClient
 from tokenmizer.api import app as app_module
 from tokenmizer.api.app import app
 from tokenmizer.providers.providers import LLMResponse
+from tokenmizer.semantic_cache.cache import CacheEntry
 
 
 def _fake_response(text: str = "hello from fake provider") -> LLMResponse:
@@ -148,6 +150,49 @@ class TestChatCompletionsE2E:
         assert '"content": " streamed"' in body
         assert '"finish_reason": "stop"' in body
         assert body.rstrip().endswith("data: [DONE]")
+
+    from time import time
+
+    from tokenmizer.semantic_cache.cache import CacheEntry
+
+    def test_streaming_cache_hit_recorded_in_analytics(self, client, monkeypatch):
+        c, _ = client
+
+        from tokenmizer.api import app as app_module
+
+        monkeypatch.setattr(app_module.settings.cache, "enabled", True)
+
+        monkeypatch.setattr(
+            app_module._cache,
+            "get",
+            lambda *a, **k: CacheEntry(
+                key="k",
+                prompt="p",
+                response="cached response",
+                input_tokens=1,
+                output_tokens=1,
+                created_at=time(),
+            ),
+        )
+
+        recorded = {}
+
+        monkeypatch.setattr(
+            app_module._analytics,
+            "record",
+            lambda **kwargs: recorded.update(kwargs),
+        )
+
+        r = c.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "cached"}],
+                "stream": True,
+            },
+        )
+
+        assert r.status_code == 200
+        assert recorded["cache_hit"] is True
 
     def test_streaming_unsupported_provider_returns_501(self, client, monkeypatch):
         """Providers without chat_stream override must get a clear 501,

--- a/tokenmizer/api/app.py
+++ b/tokenmizer/api/app.py
@@ -636,25 +636,36 @@ def _stream_response(req, messages, model, user_content, session_id,
     async def _gen():
         full_text = ""
         t0 = time.monotonic()
+        cache_hit = False
         yield _chunk({"role": "assistant"})
         try:
-            cached = (_cache.get(user_content, session_id=session_id)
-                      if settings.cache.enabled and user_content else None)
+            cached = (
+                _cache.get(user_content, session_id=session_id)
+                if settings.cache.enabled and user_content
+                else None
+            )
+
+            cache_hit = cached is not None
+
             if cached:
                 full_text = cached.response
                 yield _chunk({"content": full_text})
             else:
                 async for piece in provider.chat_stream(
-                    messages=messages, model=model,
+                    messages=messages,
+                    model=model,
                     max_tokens=req.max_tokens or 4096,
                     **_sampling_kwargs(req),
                 ):
                     full_text += piece
                     yield _chunk({"content": piece})
+
         except ProviderError as e:
             # Mid-stream failure: SSE can't change the status code anymore —
-            # emit an explicit error event instead of silently truncating.
-            yield "data: " + _json.dumps({"error": {"message": str(e), "type": "provider_error"}}) + "\n\n"
+            #emit an explicit error event instead of silently truncating.
+            yield "data: " + _json.dumps(
+                {"error": {"message": str(e), "type": "provider_error"}}
+            ) + "\n\n"
         yield _chunk({}, finish="stop")
         yield "data: [DONE]\n\n"
 
@@ -670,7 +681,7 @@ def _stream_response(req, messages, model, user_content, session_id,
             input_tokens_original=orig_input_tokens,
             input_tokens_sent=input_tokens, output_tokens=output_tokens,
             tokens_saved=sum(savings.values()), latency_ms=latency_ms,
-            cache_hit=False, layer_savings=savings,
+            cache_hit=cache_hit, layer_savings=savings,
         )
 
     return StreamingResponse(_gen(), media_type="text/event-stream",


### PR DESCRIPTION
## Summary

This PR fixes incorrect cache hit reporting in the streaming endpoint.

### Changes

- Track whether a streaming response was served from the semantic cache.
- Pass the computed `cache_hit` value to `_analytics.record()`.
- Add a regression test covering the cached streaming path.

Fixes #30.