### PR TITLE
docs: rewrite CONTRIBUTING.md, credit external contributors in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,13 @@
 # Contributing to TokenMizer
 
-Thank you for helping make AI context management better.
+Thanks for considering a contribution. This document covers setup, review
+expectations, and the areas where a PR is most likely to land.
 
 ## Project Philosophy
 
-**Quality over quantity.** The graph extraction pipeline (Graph → Checkpoint → Resume) is the core value. Every contribution that improves extraction accuracy, resume quality, or context continuity is more valuable than new features.
+Quality over quantity. The core value chain is Graph → Checkpoint → Resume;
+a contribution that improves extraction accuracy, resume quality, or context
+continuity is worth more than a new surface feature.
 
 ---
 
@@ -14,146 +17,165 @@ Thank you for helping make AI context management better.
 git clone https://github.com/Shweta-Mishra-ai/tokenmizer
 cd tokenmizer
 
-# Install with dev dependencies
 pip install -e ".[dev]"
 
-# Verify setup
 pytest tests/ -v
 ruff check tokenmizer/
 ```
 
 ---
 
-## Before You Open a PR
+## Before Opening a PR
 
 ```bash
-# All tests must pass
-pytest tests/ -v
+pytest tests/ -v                                # full suite must pass
+ruff check tokenmizer/                          # no lint errors
+pytest tests/memory_accuracy/ -v                # extraction-accuracy regression check
+python scripts/mcp_e2e_check.py                 # MCP stdio transport, end to end
 
-# No linting errors
-ruff check tokenmizer/
-
-# Memory accuracy regression check
-pytest tests/memory_accuracy/ -v
-
-# Optional but appreciated
+# Optional, appreciated for extraction-affecting changes:
 python -m benchmarks.checkpoint_accuracy.runner
 ```
 
+CI runs the same suite across Python 3.10–3.12 on Linux and 3.12 on Windows,
+plus a lint pass and a Docker build/health check. A PR that fails any of
+these will not be merged as-is.
+
 ---
 
-## What We Welcome
+## What We're Looking For
 
-### High Priority
-- **Graph extraction improvements** — better patterns, LLM prompt tuning, new node type detection
-- **Decision tracker** — new topic categories, better `_is_same_decision` normalization
-- **Memory accuracy tests** — real-world session data (anonymized) for benchmarking
-- **Bug fixes** — check open issues, especially extraction misses
-- **Provider fixes** — new providers or fixes to existing ones
+### High priority
+- **Graph extraction accuracy** — real transcripts where a task, decision,
+  or file is missed; new regex/heuristic patterns; LLM-pass prompt tuning
+- **Decision tracker** — new topic buckets in `decision_tracker.py`,
+  sharper `_is_same_decision` matching (the negation and semantic-opposite
+  fixes merged so far are representative of the contribution this module
+  rewards)
+- **Reasoning and ontology** — `graph_memory/reasoning.py` and
+  `graph_memory/ontology.py` are recent additions; consistency-check
+  rules, additional `why()` / `impact()` query shapes, and ontology
+  coverage of edge cases are all in scope
+- **Bug fixes** — see [open issues](https://github.com/Shweta-Mishra-ai/tokenmizer/issues),
+  particularly the `bug` and `help wanted` labels
+- **Provider support** — new providers, or fixes to existing ones
 
-### Medium Priority
-- **File intelligence** — better extraction for new file types (docx, parquet, etc.)
-- **Compression heuristics** — patterns that reduce tokens without losing meaning
-- **Performance improvements** — faster graph operations for large sessions
+### Medium priority
+- **File intelligence** — extraction for additional file types (docx,
+  parquet, etc.)
+- **Compression heuristics** — patterns that reduce tokens without losing
+  meaning
+- **Performance** — graph operations on large sessions (see the open
+  issue on `_persist()`'s full-rewrite cost)
 
-### Currently Not Accepting
+### Out of scope for now
 - New dashboard UI features
-- New MCP tools beyond the existing 5
+- New MCP tools beyond the current six, without a prior issue discussing the use case
 - Provider-specific wrapper features
-- Changes to the public API response format without discussion
+- Changes to the public API response format without prior discussion
+
+If you're unsure whether something fits, open an issue first — it's a
+much cheaper way to find out than a full PR.
 
 ---
 
 ## Code Standards
 
 ### Style
-- Python 3.10+ type hints on all public functions
-- Docstrings on all public classes and methods
-- `ruff` for linting — run `ruff check tokenmizer/ --fix` before committing
+- Python 3.10+ type hints on public functions
+- Docstrings on public classes and methods
+- `ruff check tokenmizer/ --fix` before committing
+- Comments should be short and factual, describing a constraint or
+  invariant the code doesn't already make obvious — not a narration of
+  what the code does, and not a log of how a bug was found
 
-### Architecture Rules
-- **No raw dicts across layer boundaries** — use DTOs from `tokenmizer/core/dto.py`
-- **No `os.getenv()` outside `config/settings.py`** — inject settings
-- **All external imports are lazy** — use `try: import X except ImportError` inside methods
-- **Every provider must return `LLMResponseDTO`** — no provider-specific types leaking up
+### Architecture rules
+- No raw dicts across layer boundaries — use the DTOs in `tokenmizer/core/dto.py`
+- No `os.getenv()` outside `config/settings.py` — inject settings instead
+- External imports are lazy — `try: import X except ImportError` inside the function that needs it
+- Every provider returns `LLMResponseDTO` — no provider-specific type leaks upward
 
-### Testing Rules
-- New extraction patterns → add to `tests/memory_accuracy/`
-- New provider → add to `tests/unit/` with mocked responses
-- Chaos scenarios → add to `tests/chaos/`
-- Coverage target: 70% minimum (enforced in CI)
+### Testing
+- New extraction pattern → a test in `tests/memory_accuracy/` or `tests/unit/test_decision_tracker.py`
+- New provider → `tests/unit/` with mocked responses
+- Chaos/failure-mode scenario → `tests/chaos/`
+- Match the existing test style: a docstring stating the invariant being
+  guarded, not a changelog entry
 
 ---
 
-## Graph Extraction Contributions
+## Contributing to Graph Extraction
 
-This is the most impactful area. The heuristic extractor in `tokenmizer/graph_memory/graph.py` misses real-world phrases. To improve it:
+This is the area with the most leverage. The heuristic extractor
+(`tokenmizer/graph_memory/hybrid_extractor.py`, with fallback logic in
+`graph.py`) misses real-world phrasing regularly.
 
-1. Find a phrase pattern that gets missed
-2. Write a test showing it's missed:
+1. Find a phrase that should produce a node but doesn't.
+2. Write a failing test:
 
 ```python
 def test_new_pattern():
     msgs = [{"role": "assistant", "content": "The database migration is complete."}]
-    r = _heuristic_extract(msgs)
-    task_labels = " ".join(t["label"].lower() for t in r["tasks"])
-    assert "database migration" in task_labels or "migration" in task_labels
+    result = extractor.heuristic_extract(msgs)
+    labels = " ".join(t.lower() for t in result.tasks_done)
+    assert "migration" in labels
 ```
 
-3. Add the pattern to `graph.py`
-4. Verify the test passes
-5. Run the full memory accuracy suite to check for regressions
+3. Add the pattern.
+4. Confirm the test passes and run the full memory-accuracy suite to check
+   for regressions elsewhere.
 
 ---
 
-## Decision Tracker Contributions
+## Contributing to the Decision Tracker
 
-To add a new topic category to `tokenmizer/graph_memory/decision_tracker.py`:
+To add a topic bucket in `tokenmizer/graph_memory/decision_tracker.py`:
 
 ```python
-# Add to _TOPIC_KEYWORDS dict:
+# In _TOPIC_KEYWORDS:
 "monitoring": ["datadog", "grafana", "prometheus", "sentry", "newrelic",
                "logging", "observability", "monitoring platform"],
 ```
 
-Then test it:
 ```python
-from tokenmizer.graph_memory.decision_tracker import classify_topic
-assert classify_topic("Use Datadog for monitoring") == "monitoring"
-assert classify_topic("Grafana for metrics") == "monitoring"
+from tokenmizer.graph_memory.decision_tracker import classify_topics
+assert "monitoring" in classify_topics("Use Datadog for monitoring")
+assert "monitoring" in classify_topics("Grafana for metrics")
 ```
+
+`classify_topics()` returns a set — a decision can legitimately belong to
+more than one bucket (e.g. "Use FastAPI with PostgreSQL" touches both
+`web_framework` and `database`). Don't special-case single-topic matching.
 
 ---
 
-## Issue Reports
-
-When reporting a bug, include:
+## Reporting an Issue
 
 ```
-Python version: 3.x.x
-OS: macOS / Linux / Windows
-Provider: anthropic / openai / etc.
+Python version:
+OS:
+Provider:
 
 What happened:
-[describe]
 
 Expected:
-[describe]
 
 Minimal reproduction:
-[code or session transcript]
 ```
 
-For extraction misses, include the actual message text where the node should have been extracted.
+For an extraction miss, include the exact message text where a node
+should have been created — that transcript is the reproduction.
 
 ---
 
 ## Questions
 
-Open a GitHub Discussion — not an issue.
+Open a GitHub Discussion rather than an issue for anything that isn't a
+concrete bug or feature request.
 
 ---
 
 ## License
 
-By contributing, you agree your contributions will be licensed under MIT.
+By contributing, you agree your contribution is licensed under the
+project's MIT license.

--- a/README.md
+++ b/README.md
@@ -579,8 +579,8 @@ tokenmizer stats
 | Version | Focus |
 |---|---|
 | **v0.3** | SSE streaming passthrough (checkpoint on stream close) |
-| v0.4 | Cross-session memory · embedding-based edge linking |
-| v0.5 | Per-node storage schema (scale past 200-node graphs) |
+| **v0.4** | Graph ontology · deterministic reasoning API (`why`, `impact`, consistency checks) |
+| v0.5 | Cross-session memory · embedding-based edge linking · per-node storage schema (scale past 200-node graphs) |
 | Research | Real-transcript benchmark suite → paper ([tokenmizer-research](https://github.com/Shweta-Mishra-ai/tokenmizer-research)) |
 
 Have a use case that doesn't fit? [Open an issue](https://github.com/Shweta-Mishra-ai/tokenmizer/issues/new/choose) — extraction misses have their own issue template.
@@ -595,17 +595,27 @@ Contributions welcome — this project merges fast (median PR review < 1 day).
 git clone https://github.com/Shweta-Mishra-ai/tokenmizer
 cd tokenmizer
 pip install -e ".[dev]"
-pytest tests/ -v && ruff check tokenmizer/     # 262 tests, must stay green
+pytest tests/ -v && ruff check tokenmizer/     # 302 tests, must stay green
 python scripts/mcp_e2e_check.py                # full-pipeline e2e check
 ```
 
 **Highest-impact areas right now:**
 
 1. **Graph extraction quality** — real-world transcripts where extraction misses tasks/decisions (file an [extraction-miss issue](.github/ISSUE_TEMPLATE/extraction_miss.md) even if you don't fix it — the failing transcript itself is the contribution)
-2. **SSE streaming** (v0.3 headline feature)
-3. **Benchmark sessions** — add a real session + ground truth to `benchmarks/`
+2. **Decision tracker edge cases** — negation, semantic opposites, and same-decision matching are an active area (see recent merges below)
+3. **Reasoning and ontology** (`graph_memory/reasoning.py`, `graph_memory/ontology.py`) — new in v0.4, still growing
+4. **Benchmark sessions** — add a real session + ground truth to `benchmarks/`
 
-Every PR runs the full CI gauntlet (tests × 3 Python versions, lint, Docker build). See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [TESTING.md](TESTING.md) for the test architecture.
+Every PR runs the full CI gauntlet (tests × 3 Python versions on Linux, one Python version on Windows, lint, Docker build). See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [TESTING.md](TESTING.md) for the test architecture.
+
+### Contributors
+
+Thanks to everyone who has sent a fix upstream:
+
+- [**@0xfroOty**](https://github.com/0xfroOty) — negated-decision handling in the decision tracker ([#22](https://github.com/Shweta-Mishra-ai/tokenmizer/pull/22)), `OutputTrimmer` level alignment ([#25](https://github.com/Shweta-Mishra-ai/tokenmizer/pull/25)), streaming cache-hit analytics ([#31](https://github.com/Shweta-Mishra-ai/tokenmizer/pull/31))
+- [**@pollychen-lab**](https://github.com/pollychen-lab) — graph node IDs derived from stored (truncated) labels ([#21](https://github.com/Shweta-Mishra-ai/tokenmizer/pull/21)), semantic-opposite decision detection ([#26](https://github.com/Shweta-Mishra-ai/tokenmizer/pull/26))
+
+Open a PR — [CONTRIBUTING.md](CONTRIBUTING.md) covers setup and review expectations.
 
 ---
 


### PR DESCRIPTION
## Summary
- Rewrote `CONTRIBUTING.md`: corrected stale code references (module layout, `classify_topics`), added reasoning/ontology as a contribution area, removed an unenforced coverage-threshold claim, updated tool count and CI matrix description.
- Added a **Contributors** section to the README crediting the two external contributors merged so far — [@0xfroOty](https://github.com/0xfroOty) (#22, #25, #31) and [@pollychen-lab](https://github.com/pollychen-lab) (#21, #26).
- Updated the quick-start test count (262 → 302) and roadmap table to reflect v0.4.0 shipping.

Docs-only change; no code touched.

## Test plan
- [x] Reviewed all code/API references in CONTRIBUTING.md against the current source tree
- [x] Verified contributor PR numbers and links
- N/A — no code changes, no test suite impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)