### PR TITLE
fix(dashboard): authenticate stats requests

### DIFF
--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,0 +1,20 @@
+from tokenmizer.dashboard.page import DASHBOARD_HTML
+
+
+def test_dashboard_retries_stats_requests_with_session_api_key():
+    assert "sessionStorage.getItem(API_KEY_STORAGE_KEY)" in DASHBOARD_HTML
+    assert "sessionStorage.setItem(API_KEY_STORAGE_KEY, key)" in DASHBOARD_HTML
+    assert "Authorization: `Bearer ${apiKey}`" in DASHBOARD_HTML
+    assert "response.status !== 401" in DASHBOARD_HTML
+
+    assert "dashboardFetch('/api/stats')" in DASHBOARD_HTML
+    assert "dashboardFetch('/api/cache/stats')" in DASHBOARD_HTML
+    assert "fetch('/api/stats')" not in DASHBOARD_HTML
+    assert "fetch('/api/cache/stats')" not in DASHBOARD_HTML
+
+
+def test_dashboard_shares_a_single_api_key_prompt_between_requests():
+    assert "let apiKeyPrompt = null;" in DASHBOARD_HTML
+    assert "if (!apiKeyPrompt)" in DASHBOARD_HTML
+    assert "window.prompt(" in DASHBOARD_HTML
+    assert "apiKeyPrompt = null;" in DASHBOARD_HTML

--- a/tokenmizer/dashboard/page.py
+++ b/tokenmizer/dashboard/page.py
@@ -230,11 +230,60 @@ Continue from: Add rate limiting to auth endpoints</div>
 </footer>
 
 <script>
+const API_KEY_STORAGE_KEY = 'tokenmizer.apiKey';
+let apiKeyPrompt = null;
+let apiKeyPromptDismissed = false;
+
+function getStoredApiKey() {
+  return sessionStorage.getItem(API_KEY_STORAGE_KEY) || '';
+}
+
+function authOptions(apiKey) {
+  return apiKey ? {headers: {Authorization: `Bearer ${apiKey}`}} : {};
+}
+
+async function requestApiKey() {
+  if (apiKeyPromptDismissed) return null;
+
+  if (!apiKeyPrompt) {
+    apiKeyPrompt = Promise.resolve()
+      .then(() => window.prompt('TokenMizer API key'))
+      .then(value => {
+        const key = (value || '').trim();
+        if (!key) {
+          apiKeyPromptDismissed = true;
+          return null;
+        }
+        sessionStorage.setItem(API_KEY_STORAGE_KEY, key);
+        return key;
+      })
+      .finally(() => {
+        apiKeyPrompt = null;
+      });
+  }
+
+  return apiKeyPrompt;
+}
+
+async function dashboardFetch(path) {
+  let apiKey = getStoredApiKey();
+  let response = await fetch(path, authOptions(apiKey));
+  if (response.status !== 401) return response;
+
+  if (apiKey) {
+    sessionStorage.removeItem(API_KEY_STORAGE_KEY);
+  }
+  apiKey = await requestApiKey();
+  if (!apiKey) return response;
+
+  return fetch(path, authOptions(apiKey));
+}
+
 async function loadStats() {
   try {
     const [statsRes, cacheRes] = await Promise.all([
-      fetch('/api/stats').catch(() => null),
-      fetch('/api/cache/stats').catch(() => null),
+      dashboardFetch('/api/stats').catch(() => null),
+      dashboardFetch('/api/cache/stats').catch(() => null),
     ]);
 
     if (statsRes && statsRes.ok) {


### PR DESCRIPTION
## What this PR does

- retries dashboard stats requests after a `401 Unauthorized`
- prompts for the configured TokenMizer API key once and keeps it in `sessionStorage`
- sends the key as `Authorization: Bearer ...` for both stats endpoints
- shares one in-flight prompt across the concurrent requests and clears stale stored keys
- adds regression coverage for the authentication flow

## Why

When `TOKENMIZER_API_KEY` is configured, `/api/stats` and `/api/cache/stats` require authentication, but the dashboard fetched both endpoints without headers. The page loaded while every stats request failed with `401`, leaving the dashboard values empty.

Using `sessionStorage` keeps the credential scoped to the current tab session, as requested in #34, instead of persisting it in `localStorage`.

## Type

- [x] Bug fix
- [ ] Extraction improvement (graph_memory/)
- [ ] New provider
- [ ] Performance
- [ ] Documentation

## Tests

- [x] `pytest tests/ -v` passes
- [x] `ruff check tokenmizer/ tests/` clean
- [x] Memory accuracy test added/updated (not applicable)

Validated locally on Python 3.12.13:

- `ruff check tokenmizer/ tests/`
- `pytest tests/ --cov=tokenmizer --cov-report=term-missing --cov-report=xml -v` (`309 passed`, 68% coverage)
- `python scripts/mcp_e2e_check.py` (`ALL PASS`)
- live smoke: `/` returns 200, unauthenticated `/api/stats` returns 401, and the Bearer-authenticated request returns 200

## Checklist

- [x] No raw dicts crossing layer boundaries (use DTOs)
- [x] No `os.getenv()` outside `config/settings.py`
- [x] External imports are lazy (inside functions, with try/except ImportError)

Fixes #34

Disclosure: This contribution was implemented and validated with OpenAI Codex assistance.
