### PR TITLE
fix(api): don't leak raw exception text in admin-endpoint 500 responses

### DIFF
--- a/tests/unit/test_internal_error_leak.py
+++ b/tests/unit/test_internal_error_leak.py
@@ -1,0 +1,96 @@
+"""
+Regression tests: the checkpoint/invalidate/resume admin endpoints in
+api/routes_graph.py used to put raw exception text (`str(e)`) directly
+into the HTTP 500 response body — the same silent-internal-detail-leak
+class of bug chat_completions()'s provider-failure handler was already
+fixed against (TM-33), just not mirrored here. Fixed via a shared
+`_internal_error()` helper: full exception text goes to the server log
+with a correlation id, the client gets a generic message plus that id.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tokenmizer.api import app as app_module
+from tokenmizer.api.app import app
+from tokenmizer.api.routes_graph import _internal_error
+from tokenmizer.graph_memory.graph import GraphMemory, NodeStatus, NodeType
+
+
+class TestInternalErrorHelper:
+
+    def test_detail_does_not_contain_raw_exception_text(self, caplog):
+        secret_looking_error = RuntimeError(
+            "disk I/O error at /var/secret/prod-db/graph_memory.db"
+        )
+        with caplog.at_level(logging.ERROR):
+            exc = _internal_error("Manual checkpoint failed for session xyz", secret_looking_error)
+        assert "/var/secret/prod-db" not in str(exc.detail)
+        assert exc.status_code == 500
+
+    def test_full_detail_is_still_logged_server_side(self, caplog):
+        secret_looking_error = RuntimeError("disk I/O error at /var/secret/prod-db/graph_memory.db")
+        with caplog.at_level(logging.ERROR):
+            _internal_error("Manual checkpoint failed for session xyz", secret_looking_error)
+        assert any("/var/secret/prod-db" in r.message for r in caplog.records), (
+            "the real error must still be logged server-side even though "
+            "it's kept out of the client-facing response"
+        )
+
+    def test_response_includes_a_correlation_id_reference(self):
+        exc = _internal_error("Resume failed for session xyz", ValueError("boom"))
+        assert "ref:" in exc.detail
+
+
+@pytest.fixture(autouse=True)
+def _no_api_key(monkeypatch):
+    monkeypatch.setattr(app_module.settings, "api_key", "", raising=False)
+
+
+class TestEndpointsDoNotLeakExceptionText:
+
+    def test_checkpoint_endpoint_does_not_leak_exception_text(self, tmp_path, monkeypatch):
+        g = GraphMemory("leak-test-checkpoint", storage_dir=str(tmp_path))
+        app_module._graph_cache["leak-test-checkpoint"] = g
+
+        def _boom(*a, **k):
+            raise RuntimeError("connection string password=hunter2 leaked here")
+
+        monkeypatch.setattr(app_module._checkpoint_mgr, "create", _boom)
+
+        with TestClient(app) as c:
+            r = c.post("/api/checkpoint", params={"session_id": "leak-test-checkpoint"})
+        assert r.status_code == 500
+        assert "hunter2" not in r.text
+
+    def test_resume_endpoint_does_not_leak_exception_text(self, monkeypatch):
+        def _boom(*a, **k):
+            raise RuntimeError("connection string password=hunter2 leaked here")
+
+        monkeypatch.setattr(app_module._checkpoint_mgr, "get_latest", _boom)
+
+        with TestClient(app) as c:
+            r = c.get("/api/resume/leak-test-resume")
+        assert r.status_code == 500
+        assert "hunter2" not in r.text
+
+    def test_invalidate_decision_endpoint_does_not_leak_exception_text(self, tmp_path, monkeypatch):
+        g = GraphMemory("leak-test-invalidate", storage_dir=str(tmp_path))
+        g.add_node(NodeType.DECISION, "Use PostgreSQL for storage", NodeStatus.COMPLETED)
+        app_module._graph_cache["leak-test-invalidate"] = g
+
+        def _boom(force=False):
+            raise RuntimeError("connection string password=hunter2 leaked here")
+
+        monkeypatch.setattr(g, "_persist", _boom)
+
+        with TestClient(app) as c:
+            r = c.post(
+                "/api/decision/invalidate",
+                params={"session_id": "leak-test-invalidate", "decision_label": "postgresql"},
+            )
+        assert r.status_code == 500
+        assert "hunter2" not in r.text

--- a/tokenmizer/api/routes_graph.py
+++ b/tokenmizer/api/routes_graph.py
@@ -26,6 +26,7 @@ Pure code motion — no behavior changes.
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -38,6 +39,30 @@ from tokenmizer.security.auth import verify_api_key
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _internal_error(context: str, e: Exception) -> HTTPException:
+    """
+    Build a 500 HTTPException for an unexpected failure without leaking
+    the raw exception text to the client.
+
+    FIXED: these three handlers (checkpoint creation, decision
+    invalidation, resume) previously did `detail=str(e)` directly —
+    `str(e)` on things like `sqlite3.OperationalError` or a filesystem
+    error routinely embeds real disk paths, and other exception types
+    can include similarly internal detail. `chat_completions()`'s own
+    provider-failure handler already avoids this (see TM-33) via a
+    correlation id: full detail goes to the server log, the client gets
+    a generic message plus the id to reference when asking for help.
+    Factored out here since the same pattern was needed at all three
+    call sites — one shared helper instead of three copies.
+    """
+    correlation_id = uuid.uuid4().hex[:12]
+    logger.error(f"{context} [{correlation_id}]: {e}")
+    return HTTPException(
+        status_code=500,
+        detail=f"{context} (ref: {correlation_id}). Check server logs for details.",
+    )
 
 
 @router.get("/api/stats", dependencies=[Depends(verify_api_key), Depends(app_module._check_rate_limit)])
@@ -225,8 +250,7 @@ async def create_manual_checkpoint(session_id: str):
             "trigger": ckpt.trigger,
         }
     except Exception as e:
-        logger.error(f"Manual checkpoint failed for session {session_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _internal_error(f"Manual checkpoint failed for session {session_id}", e)
 
 
 @router.get("/api/checkpoints/{session_id}", dependencies=[Depends(verify_api_key), Depends(app_module._check_rate_limit)])
@@ -343,8 +367,7 @@ async def invalidate_decision(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Invalidate decision failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise _internal_error("Invalidate decision failed", e)
 
 
 @router.get("/api/resume/{session_id}", dependencies=[Depends(verify_api_key), Depends(app_module._check_rate_limit)])
@@ -372,5 +395,4 @@ async def get_resume(session_id: str, level: str = "standard"):
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Resume failed for {session_id}: {e}")
-        raise HTTPException(status_code=500, detail=f"Resume failed: {str(e)}")
+        raise _internal_error(f"Resume failed for {session_id}", e)


### PR DESCRIPTION
## What this PR does

`create_manual_checkpoint`, `invalidate_decision`, and `get_resume` in `api/routes_graph.py` all put raw exception text (`str(e)`) directly into their HTTP 500 response body. `chat_completions()`'s provider-failure handler already avoids this (TM-33) via a correlation id — full detail logged server-side, generic message + id returned to the client — but that fix was never mirrored to these three endpoints when they were split into their own file.

Added a shared `_internal_error()` helper (one helper instead of three duplicated try/except blocks — net complexity reduction, not an addition) and applied it at all three call sites.

## Why

`str(e)` on things like `sqlite3.OperationalError` or a filesystem error routinely embeds real disk paths or other internal detail that shouldn't reach an API client.

## Tests

- `tests/unit/test_internal_error_leak.py` (new, 6 tests): the helper itself (no raw text in client-facing detail, full text still logged server-side, response includes a correlation id) plus one end-to-end TestClient test per endpoint confirming a simulated sensitive-looking exception message never reaches the HTTP response.
- Full suite: 446 passed (440 + 6 new), `ruff check` clean.

## Type

- [x] Bug fix