### PR TITLE
0.5.1: fix broken PyPI README images and mangled release titles

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenmizer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Never lose your AI context again. Graph-backed memory, session checkpointing, and file intelligence for any LLM.",
   "homepage": "https://github.com/Shweta-Mishra-ai/tokenmizer",
   "repository": "https://github.com/Shweta-Mishra-ai/tokenmizer",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenmizer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Never lose your AI context again. Graph-backed memory, session checkpointing, and file intelligence for Claude Code and any LLM.",
   "author": {
     "name": "Shweta Mishra",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,15 +188,28 @@ jobs:
           # list of minor words, and always the first word regardless.
           # Plain `.title()` also capitalises "And"/"Of" mid-title, which
           # reads as a typo rather than a style choice.
+          #
+          # A word that already carries a capital letter (PyPI, README,
+          # MCP, CI) is left untouched rather than run through
+          # `.capitalize()`, which lowercases everything after the first
+          # letter and turns "PyPI" into "Pypi" — a second typo-shaped
+          # bug in the same function, caught only once a heading actually
+          # contained an acronym.
           _MINOR = {"a", "an", "and", "as", "at", "but", "by", "for",
                     "in", "nor", "of", "on", "or", "the", "to", "with"}
 
           def _title_case(s: str) -> str:
               words = s.split(" ")
-              return " ".join(
-                  w if (i > 0 and w.lower() in _MINOR) else w.capitalize()
-                  for i, w in enumerate(words)
-              )
+              out = []
+              for i, w in enumerate(words):
+                  core = w.rstrip(",:;")
+                  if core != core.lower():
+                      out.append(w)  # already capitalised somewhere — leave it
+                  elif i > 0 and w.lower() in _MINOR:
+                      out.append(w)
+                  else:
+                      out.append(w.capitalize())
+              return " ".join(out)
 
           heading = re.search(
               rf"^## \[{re.escape(version)}\][^\n]*—[^\n]*—\s*(.+)$",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.5.1] — 2026-08-07 — fix the PyPI README
+
+The logo and demo GIF used repo-relative paths (`docs/assets/logo.svg`).
+GitHub resolves those against the repo automatically; PyPI renders the
+README standalone with no base URL, so both images were broken on the
+PyPI project page while looking correct everywhere else — on GitHub, in
+any local Markdown preview, and in the built wheel's own README copy.
+Every relative link and image in `README.md` now points at an absolute
+`github.com`/`raw.githubusercontent.com` URL, so it renders identically
+wherever it's displayed. `test_readme_has_no_repo_relative_links_or_images`
+guards against this recurring.
+
+No functional changes. 604 tests, ruff clean.
+
 ## [0.5.0] — 2026-08-07 — audit, durability, and measured extraction quality
 
 Everything between 0.4.0 — the last version published to PyPI — and here,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="docs/assets/logo.svg" width="140" alt="TokenMizer"/>
+  <img src="https://raw.githubusercontent.com/Shweta-Mishra-ai/tokenmizer/main/docs/assets/logo.svg" width="140" alt="TokenMizer"/>
 
   <h1>TokenMizer</h1>
 
@@ -21,7 +21,7 @@
     <a href="https://pypi.org/project/tokenmizer"><img src="https://img.shields.io/pypi/dm/tokenmizer?color=5ee7c8&style=flat-square" alt="Downloads"/></a>
     <a href="https://github.com/Shweta-Mishra-ai/tokenmizer/actions"><img src="https://img.shields.io/github/actions/workflow/status/Shweta-Mishra-ai/tokenmizer/ci.yml?branch=main&style=flat-square&color=4ade80" alt="CI"/></a>
     <a href="https://registry.modelcontextprotocol.io/v0/servers?search=tokenmizer"><img src="https://img.shields.io/badge/MCP%20Registry-published-5ee7c8?style=flat-square" alt="MCP Registry"/></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-4ade80?style=flat-square"/></a>
+    <a href="https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-4ade80?style=flat-square"/></a>
     <a href="https://github.com/Shweta-Mishra-ai/tokenmizer/stargazers"><img src="https://img.shields.io/github/stars/Shweta-Mishra-ai/tokenmizer?style=flat-square&color=f9d84a" alt="Stars"/></a>
     <a href="https://glama.ai/mcp/servers/Shweta-Mishra-ai/tokenmizer"><img src="https://glama.ai/mcp/servers/Shweta-Mishra-ai/tokenmizer/badges/score.svg" alt="Glama Score"/></a>
     <a href="https://github.com/sponsors/Shweta-Mishra-ai"><img src="https://img.shields.io/badge/sponsor-%E2%9D%A4-db61a2?style=flat-square" alt="Sponsor"/></a>
@@ -30,14 +30,14 @@
   <p>
     <a href="#quick-start"><b>Quick start</b></a> ·
     <a href="#use-it-from-your-tools"><b>Claude Code &amp; MCP</b></a> ·
-    <a href="docs/architecture.md"><b>Architecture</b></a> ·
-    <a href="docs/benchmarks.md"><b>Benchmarks</b></a> ·
-    <a href="docs/configuration.md"><b>Configuration</b></a> ·
-    <a href="docs/api.md"><b>API &amp; CLI</b></a> ·
-    <a href="CONTRIBUTING.md"><b>Contributing</b></a>
+    <a href="https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/architecture.md"><b>Architecture</b></a> ·
+    <a href="https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/benchmarks.md"><b>Benchmarks</b></a> ·
+    <a href="https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/configuration.md"><b>Configuration</b></a> ·
+    <a href="https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/api.md"><b>API &amp; CLI</b></a> ·
+    <a href="https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/CONTRIBUTING.md"><b>Contributing</b></a>
   </p>
 
-  <img src="docs/assets/demo.gif" width="860" alt="TokenMizer demo: 40-turn session checkpointed at 87% context, resumed next day in 233 tokens"/>
+  <img src="https://raw.githubusercontent.com/Shweta-Mishra-ai/tokenmizer/main/docs/assets/demo.gif" width="860" alt="TokenMizer demo: 40-turn session checkpointed at 87% context, resumed next day in 233 tokens"/>
   <br/>
   <sub>Real run: 25-node graph, checkpoint <code>ckpt_21a0959c3ddf</code>, 233-token resume. Regenerate with <code>python scripts/gen_demo_gif.py</code>.</sub>
 </div>
@@ -90,7 +90,7 @@ replaced is marked superseded rather than deleted. The resume block is a
 filtered projection of it: active decisions, open work, unresolved
 errors, in a few hundred tokens.
 
-→ [**Architecture**](docs/architecture.md) — the request sequence, the
+→ [**Architecture**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/architecture.md) — the request sequence, the
 data model, and the decision lifecycle.
 
 ## Quick start
@@ -147,8 +147,8 @@ docker compose up -d
 
 Full installation notes, every provider's environment variable, and the
 configuration reference are in
-[**docs/configuration.md**](docs/configuration.md) and
-[**docs/deployment.md**](docs/deployment.md).
+[**docs/configuration.md**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/configuration.md) and
+[**docs/deployment.md**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/deployment.md).
 </details>
 
 ## Use it from your tools
@@ -194,7 +194,7 @@ Then, in any session:
 | Claude Code | `.mcp.json` in the project, or `~/.claude/settings.json` |
 | Cursor | Settings → MCP → Add server, same JSON |
 | VS Code / Zed | their MCP settings, same `command` and `env` |
-| Codex CLI | `~/.codex/config.toml` — TOML, see [docs/api.md](docs/api.md) |
+| Codex CLI | `~/.codex/config.toml` — TOML, see [docs/api.md](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/api.md) |
 
 Restart the client afterwards. Keep `tokenmizer serve` running for the
 checkpoint, resume, stats and reasoning tools; file analysis works
@@ -213,7 +213,7 @@ Any OpenAI-compatible client works by pointing `base_url` at
 Continue.dev, Aider, LangChain, LlamaIndex, the OpenAI SDKs in every
 language, and `curl`.
 
-→ [**API & CLI reference**](docs/api.md) — every endpoint, every command,
+→ [**API & CLI reference**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/api.md) — every endpoint, every command,
 every MCP tool.
 
 ## What a resume looks like
@@ -257,7 +257,7 @@ than real transcripts and a single headline hides that: **synthetic 95%,
 real 90%.** Treat 90% as the number that describes real sessions. n=14
 is a small sample and the same person wrote every label.
 
-→ [**Benchmarks**](docs/benchmarks.md) — memory quality against a
+→ [**Benchmarks**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/benchmarks.md) — memory quality against a
 plain-summary baseline, storage, and how to score your own sessions.
 
 ## Why TokenMizer and not X?
@@ -269,13 +269,13 @@ Git stores *what changed*, not *why you decided to change it*. You can't ask Git
 RAG retrieves *relevant chunks* — it doesn't model *decision state*. If you switched from bcrypt to Argon2 mid-session, RAG might retrieve both and confuse the model about which is current. TokenMizer tracks decision supersession explicitly: the old decision is marked `SUPERSEDED`, the new one `ACTIVE`, and the resume context only includes current state.
 
 **Why not a plain summary at the start of each session?**
-Summaries lose structure. You can't query "all superseded decisions" or "what triggered the auth change" from a blob of text. Our benchmark shows graph memory preserves **89%** of labelled information against **79%** for a summary baseline — +10 points — and unlike a summary, the graph is queryable, editable, and grows incrementally instead of being re-summarized every turn. See [Benchmarks](docs/benchmarks.md#memory-quality--graph-vs-a-plain-summary).
+Summaries lose structure. You can't query "all superseded decisions" or "what triggered the auth change" from a blob of text. Our benchmark shows graph memory preserves **89%** of labelled information against **79%** for a summary baseline — +10 points — and unlike a summary, the graph is queryable, editable, and grows incrementally instead of being re-summarized every turn. See [Benchmarks](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/benchmarks.md#memory-quality--graph-vs-a-plain-summary).
 
 **Why not Mem0 or Zep?**
 Mem0 and Zep store *facts* ("user prefers Python"). TokenMizer stores *decisions with rationale* — the full causal chain: what was decided, what replaced it, why, what evidence triggered the change. If you need "remember my name across sessions," use Mem0. If you need "remember that we switched from PostgreSQL to SQLite because of cost, and here's the evidence," use TokenMizer.
 
 **Why not just a longer context window?**
-Longer context means higher cost, slower inference, and attention dilution on long histories. TokenMizer compresses a session into a resume block averaging **178 tokens** (measured, n=3 — see [Benchmarks](docs/benchmarks.md)) by extracting what actually matters, not by summarizing.
+Longer context means higher cost, slower inference, and attention dilution on long histories. TokenMizer compresses a session into a resume block averaging **178 tokens** (measured, n=3 — see [Benchmarks](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/benchmarks.md)) by extracting what actually matters, not by summarizing.
 
 ## What is not implemented
 
@@ -291,15 +291,15 @@ here rather than left to be discovered:
 
 | | |
 |---|---|
-| [**Architecture**](docs/architecture.md) | Request pipeline, graph data model, decision lifecycle, file intelligence |
-| [**Configuration**](docs/configuration.md) | Every setting, environment variables, precedence, providers |
-| [**API & CLI**](docs/api.md) | Endpoints, commands, MCP tools, Claude Code integration |
-| [**Deployment**](docs/deployment.md) | Docker, multiple workers, durability, session isolation, security |
-| [**Benchmarks**](docs/benchmarks.md) | Extraction quality, memory quality, storage, running your own |
-| [**Comparisons**](docs/comparisons.md) | Mem0, Zep, longer context windows, running alongside other token tools, and the roadmap |
-| [**Contributing**](CONTRIBUTING.md) | Setup, layer rules, and how to improve extraction |
-| [**Testing**](TESTING.md) | How to run the suite, the coverage floor, and known limits of the local audit scripts |
-| [**Changelog**](CHANGELOG.md) · [**Security**](SECURITY.md) | Release history and how to report a vulnerability |
+| [**Architecture**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/architecture.md) | Request pipeline, graph data model, decision lifecycle, file intelligence |
+| [**Configuration**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/configuration.md) | Every setting, environment variables, precedence, providers |
+| [**API & CLI**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/api.md) | Endpoints, commands, MCP tools, Claude Code integration |
+| [**Deployment**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/deployment.md) | Docker, multiple workers, durability, session isolation, security |
+| [**Benchmarks**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/benchmarks.md) | Extraction quality, memory quality, storage, running your own |
+| [**Comparisons**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/comparisons.md) | Mem0, Zep, longer context windows, running alongside other token tools, and the roadmap |
+| [**Contributing**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/CONTRIBUTING.md) | Setup, layer rules, and how to improve extraction |
+| [**Testing**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/TESTING.md) | How to run the suite, the coverage floor, and known limits of the local audit scripts |
+| [**Changelog**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/CHANGELOG.md) · [**Security**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/SECURITY.md) | Release history and how to report a vulnerability |
 
 ## Contributing
 
@@ -315,12 +315,12 @@ wrong.** The eval corpus is 14 sessions and the same person wrote every
 label in it — that is the honest ceiling on what the numbers above can
 tell you about *your* workload, and the only way past it is transcripts
 nobody here wrote. Label a few of your own in the format documented in
-[`benchmarks/eval/corpus.py`](benchmarks/eval/corpus.py) and open a PR,
+[`benchmarks/eval/corpus.py`](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/benchmarks/eval/corpus.py) and open a PR,
 or [open an issue](https://github.com/Shweta-Mishra-ai/tokenmizer/issues)
 with the turn that was missed. Redact freely — the shape of the prose is
 what matters, not its content.
 
-[CONTRIBUTING.md](CONTRIBUTING.md) covers setup, the layer rules, and how
+[CONTRIBUTING.md](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/CONTRIBUTING.md) covers setup, the layer rules, and how
 to run the eval harness.
 
 ### Contributors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenmizer"
-version = "0.5.0"
+version = "0.5.1"
 description = "Graph-backed checkpoint and resume for LLM sessions. An OpenAI-compatible proxy that remembers decisions across context limits."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Shweta-Mishra-ai/tokenmizer",
     "source": "github"
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "tokenmizer",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -217,3 +217,20 @@ class TestReleaseNotes:
         assert not mid_title_minor_caps, (
             f"minor word(s) capitalised mid-title: {mid_title_minor_caps} in {title!r}"
         )
+
+    def test_the_title_does_not_mangle_words_that_are_already_capitalised(
+        self, wf, tmp_path
+    ):
+        """`.capitalize()` lowercases everything after the first letter,
+        so an acronym run through it unconditionally turns "PyPI" into
+        "Pypi" and "README" into "Readme" — the same shape of bug as the
+        minor-word one above, in the same function, caught only once a
+        heading happened to contain one. The current version's own
+        heading does ("fix the PyPI README"), so this runs the real
+        extractor rather than a copy of its logic."""
+        import tokenmizer
+
+        _, _, title = self._run(wf, tokenmizer.__version__, tmp_path)
+        assert "Pypi" not in title and "Readme" not in title, (
+            f"acronym mangled by title-casing: {title!r}"
+        )

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -376,3 +376,26 @@ def test_mcp_name_tag_is_never_visible_prose():
                     f"{path.name}: 'mcp-name:' outside an HTML comment "
                     f"renders as visible text: {line!r}"
                 )
+
+
+def test_readme_has_no_repo_relative_links_or_images():
+    """A relative path resolves on GitHub because GitHub knows the repo
+    root — it resolves against nothing on PyPI, which renders this same
+    file standalone with no base URL. `docs/assets/logo.svg` was a
+    broken image on the PyPI project page while looking correct in every
+    local preview and on GitHub itself, which is exactly why this needs
+    a test rather than a glance. Same-page anchors (`#quick-start`) are
+    fine everywhere and excluded.
+    """
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    offenders = []
+    for target in re.findall(r'(?:href|src)="([^"]+)"', readme):
+        if not target.startswith(("http://", "https://", "#")):
+            offenders.append(target)
+    for target in re.findall(r'\[[^\]]+\]\(([^)]+)\)', readme):
+        if not target.startswith(("http://", "https://", "#")):
+            offenders.append(target)
+    assert not offenders, (
+        "these README links/images are repo-relative and will break on "
+        f"PyPI's standalone rendering: {offenders}"
+    )

--- a/tokenmizer/__init__.py
+++ b/tokenmizer/__init__.py
@@ -1,6 +1,6 @@
 """TokenMizer — Never lose your AI context again."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = ["GraphMemory", "CheckpointManager", "get_settings"]
 
 


### PR DESCRIPTION
## Summary
- README.md's logo and demo GIF used repo-relative paths (`docs/assets/logo.svg`), which GitHub resolves automatically but PyPI does not — both images were broken on the PyPI project page. Every relative link/image in README.md is now an absolute `github.com`/`raw.githubusercontent.com` URL.
- `_title_case()` in the release workflow ran every word through `.capitalize()`, silently mangling already-capitalized acronyms ("PyPI" → "Pypi", "README" → "Readme"). Words that already carry a capital letter are now left untouched.
- New guard test `test_readme_has_no_repo_relative_links_or_images`, mutation-tested against the original bug.
- Version bumped to 0.5.1 across all pinned manifests (pyproject.toml, tokenmizer/__init__.py, server.json, plugin.json, marketplace.json).

## Test plan
- [x] `pytest -q` — 605 passed
- [x] `ruff check .` — clean
- [x] Verified title-case fix against the real CHANGELOG heading for both 0.5.0 and 0.5.1
- [x] Mutation-tested the new README-link guard by reintroducing the original relative path and confirming it fails

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YbZpEMC3DgHFwV5FiaaQJU)_