### PR TITLE
0.5.2: fix stale test count, guard against dead in-page anchors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenmizer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Never lose your AI context again. Graph-backed memory, session checkpointing, and file intelligence for any LLM.",
   "homepage": "https://github.com/Shweta-Mishra-ai/tokenmizer",
   "repository": "https://github.com/Shweta-Mishra-ai/tokenmizer",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenmizer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Never lose your AI context again. Graph-backed memory, session checkpointing, and file intelligence for Claude Code and any LLM.",
   "author": {
     "name": "Shweta Mishra",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.5.2] — 2026-08-07 — a stale test count, and a guard for dead in-page anchors
+
+`README.md`, `TESTING.md`, `CONTRIBUTING.md` and `docs/benchmarks.md` all
+quoted "600 tests" next to a command a reader can actually run. The
+suite had already grown to 606 by the time this was checked — the
+existing guard (`test_readme_test_count_matches_reality`) allows a 5%
+drift on purpose so one new test doesn't red the build, and a 6-test
+drift fell inside it. Correct here means exact, not within tolerance,
+so all four are now the real number a fresh `pytest -q` reports.
+
+Also added `test_internal_markdown_anchors_point_at_real_headings`:
+`file.md#some-anchor` renders as a clickable link whether or not
+`some-anchor` exists — Markdown doesn't validate fragments, and neither
+does an HTTP status check, since the fragment is resolved by the
+browser after the page has already returned 200. The two anchors this
+project links to internally (`docs/benchmarks.md#memory-quality--…`,
+`README.md#why-tokenmizer-and-not-x`) were checked by hand against
+GitHub's slug algorithm and are correct; the new test makes that
+mechanical instead of something someone has to redo by hand next time
+either heading's wording changes.
+
+No functional changes. 606 tests, ruff clean.
+
 ## [0.5.1] — 2026-08-07 — fix the PyPI README
 
 The logo and demo GIF used repo-relative paths (`docs/assets/logo.svg`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ tokenmizer/
 │   ├── graph_retrieval/          # category recall
 │   ├── persistence/              # write amplification + concurrency
 │   └── latency/                  # end-to-end proxy latency (needs a running server)
-└── tests/                        # 44 files, 600 tests — see TESTING.md for how to run them
+└── tests/                        # 44 files, 606 tests — see TESTING.md for how to run them
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ here rather than left to be discovered:
 git clone https://github.com/Shweta-Mishra-ai/tokenmizer
 cd tokenmizer
 pip install -e ".[dev]"
-pytest tests/ -q && ruff check tokenmizer/     # 600 tests, must stay green
+pytest tests/ -q && ruff check tokenmizer/     # 606 tests, must stay green
 ```
 
 **The most valuable contribution is a session where extraction got it

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,12 +1,12 @@
 # Testing
 
-The suite is 600 tests under `pytest`, and it is the source of truth —
+The suite is 606 tests under `pytest`, and it is the source of truth —
 if a claim elsewhere in the docs disagrees with what the suite does, the
 suite is right and the docs are a bug.
 
 ```bash
 pip install -e ".[dev]"
-pytest tests/ -v              # 600 tests
+pytest tests/ -v              # 606 tests
 ruff check tokenmizer/ tests/ # lint, import order
 ```
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -10,7 +10,7 @@ python -m benchmarks.eval --errors                   # every miss, every false p
 python -m benchmarks.eval --corpus DIR               # score YOUR sessions
 python -m benchmarks.checkpoint_accuracy.runner_v2   # graph vs summary
 python -m benchmarks.persistence.runner              # storage + concurrency
-pytest tests/ -q                                     # 600 tests
+pytest tests/ -q                                     # 606 tests
 ```
 
 ## Extraction quality — precision, recall and F1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tokenmizer"
-version = "0.5.1"
+version = "0.5.2"
 description = "Graph-backed checkpoint and resume for LLM sessions. An OpenAI-compatible proxy that remembers decisions across context limits."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Shweta-Mishra-ai/tokenmizer",
     "source": "github"
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "tokenmizer",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -399,3 +399,70 @@ def test_readme_has_no_repo_relative_links_or_images():
         "these README links/images are repo-relative and will break on "
         f"PyPI's standalone rendering: {offenders}"
     )
+
+
+def _github_slug(heading_text: str) -> str:
+    """Reproduce GitHub's heading-anchor slug closely enough to check a
+    link against it: lowercase, drop anything that isn't a word
+    character/space/hyphen (this is what makes an em dash disappear
+    while the space on each side of it survives), then turn each
+    remaining space into a hyphen — deliberately not collapsed, since
+    that is what turns "quality — graph" into "quality--graph"."""
+    s = heading_text.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"\s", "-", s)
+    return s
+
+
+def test_internal_markdown_anchors_point_at_real_headings():
+    """A link to `file.md#some-anchor` renders as a working link
+    regardless of whether `some-anchor` exists — Markdown does not
+    validate fragments, and neither does an HTTP status check, since a
+    fragment is resolved by the browser after the page already loaded
+    with a 200. The only way this class of bug surfaces is a reader
+    clicking it and landing at the top of the wrong page instead of the
+    section that was promised.
+    """
+    docs_dir = ROOT / "docs"
+    scanned = [ROOT / "README.md", *sorted(docs_dir.glob("*.md"))]
+
+    def headings_of(path: Path) -> set[str]:
+        text = path.read_text(encoding="utf-8")
+        return {
+            _github_slug(h)
+            for h in re.findall(r"^#{1,6}\s+(.+?)\s*$", text, re.MULTILINE)
+        }
+
+    heading_cache = {p: headings_of(p) for p in scanned}
+
+    def resolve(path_str: str, from_file: Path) -> Path | None:
+        if not path_str:
+            return from_file
+        candidate = (from_file.parent / path_str).resolve()
+        return candidate if candidate.exists() else None
+
+    offenders = []
+    prefix = "https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/"
+    for path in scanned:
+        text = path.read_text(encoding="utf-8")
+        links = re.findall(r'\(([^)]+)\)', text) + re.findall(r'href="([^"]+)"', text)
+        for link in links:
+            if link.startswith(prefix) and "#" in link:
+                rel, frag = link[len(prefix):].split("#", 1)
+            elif link.startswith("#"):
+                rel, frag = "", link[1:]
+            elif not link.startswith(("http://", "https://")) and ".md#" in link:
+                rel, frag = link.split("#", 1)
+            else:
+                continue
+
+            target = resolve(rel, path)
+            if target is None or target not in heading_cache:
+                continue  # covered by other guards; not this test's job
+            if frag not in heading_cache[target]:
+                offenders.append(f"{path.name}: #{frag} -> {target.name}")
+
+    assert not offenders, (
+        "these links point at a fragment no heading actually produces "
+        f"(dead in-page anchor once clicked): {offenders}"
+    )

--- a/tokenmizer/__init__.py
+++ b/tokenmizer/__init__.py
@@ -1,6 +1,6 @@
 """TokenMizer — Never lose your AI context again."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __all__ = ["GraphMemory", "CheckpointManager", "get_settings"]
 
 


### PR DESCRIPTION
## Summary
- README.md, TESTING.md, CONTRIBUTING.md and docs/benchmarks.md all quoted "600 tests" while the suite had grown to 606. The existing guard allows 5% drift so CI didn't catch it — fixed to the exact number.
- Added `test_internal_markdown_anchors_point_at_real_headings`: verifies `file.md#anchor` links actually resolve to a real heading slug, since Markdown/HTTP status checks can't catch a dead in-page anchor (the fragment is resolved client-side after a 200). Manually verified the two anchors this project uses against GitHub's slug algorithm — both correct — and mutation-tested the new guard.
- Version bumped to 0.5.2.

## Test plan
- [x] `pytest -q` — 606 passed
- [x] `ruff check .` — clean
- [x] Mutation-tested the new anchor guard by breaking a real anchor and confirming it fails

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YbZpEMC3DgHFwV5FiaaQJU)_