### PR TITLE
Audit fixes: registry MCP launch, token-count undercounts, redaction gap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "ruff>=0.5.0",
     "anthropic>=0.30.0",
     "openai>=1.35.0",
+    "google-generativeai>=0.7.0",
 ]
 
 # Install everything

--- a/server.json
+++ b/server.json
@@ -13,6 +13,13 @@
       "identifier": "tokenmizer",
       "version": "0.5.2",
       "transport": { "type": "stdio" },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "description": "Runs the MCP stdio server. The pypi console script matching this package's own name (tokenmizer) is the CLI, not the MCP server — 'mcp' selects the MCP subcommand so an installer that runs `tokenmizer <packageArguments>` reaches it (the server.json schema has no separate field for a differently named entry point)."
+        }
+      ],
       "environmentVariables": [
         {
           "name": "TOKENMIZER_URL",

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -347,3 +347,22 @@ class TestFirstRunOutput:
 
         out = _plain(CliRunner().invoke(cli_app, ["stats", "--help"]).output)
         assert "--server" in out, out
+
+
+class TestMcpCommand:
+    """`tokenmizer mcp` — registries that install the pypi package and
+    invoke it by its own name (`uvx tokenmizer`, or `tokenmizer` after a
+    plain `pip install`) reach this CLI, not the separate `tokenmizer-mcp`
+    console script. server.json's packageArguments passes "mcp" so that
+    convention lands on the MCP stdio server instead of Typer's usage
+    text — see server.json and the mcp() command's docstring."""
+
+    def test_dispatches_to_the_stdio_server(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "tokenmizer.mcp.server.run_stdio_server",
+            lambda: calls.append(True),
+        )
+        res = runner.invoke(app, ["mcp"])
+        assert res.exit_code == 0, res.output
+        assert calls == [True]

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -1,0 +1,167 @@
+"""
+Regression tests for tokenmizer/providers/providers.py.
+
+providers.py has 6 provider adapters and, before this file, zero
+dedicated tests (20% coverage) — everything that exercised it did so
+incidentally through analytics/audit tests that mock the provider away
+entirely, never the adapter's own translation logic.
+
+Bug covered here: AnthropicProvider._call()'s buffered-streaming branch
+(reached via BaseProvider.chat(..., stream=True), a documented parameter
+on the public class API even though nothing in the API layer currently
+calls it that way — real streaming goes through chat_stream() instead)
+computed input_tokens as `count_messages_tokens(conv, model)`, where
+`conv` has the system message stripped out (Anthropic takes system as a
+separate top-level param, not a message). Nothing added the system
+prompt's tokens back in, so any caller using stream=True with a system
+prompt got a silently undercounted input_tokens — corrupting cost/
+savings analytics with no error, no log line, nothing. The non-streaming
+branch never had this problem because it reads token counts straight off
+`resp.usage`, the real API-reported figures. The fix makes the streaming
+branch do the same via the SDK's `get_final_message()`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from tokenmizer.providers.providers import AnthropicProvider, GeminiProvider
+
+
+@dataclass
+class _FakeUsage:
+    input_tokens: int
+    output_tokens: int
+
+
+@dataclass
+class _FakeFinalMessage:
+    usage: _FakeUsage
+    stop_reason: str = "end_turn"
+
+
+class _FakeMessageStream:
+    """Mimics anthropic's MessageStreamManager: async context manager
+    exposing `.text_stream` and `.get_final_message()`."""
+
+    def __init__(self, chunks: list[str], final: _FakeFinalMessage):
+        self._chunks = chunks
+        self._final = final
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def _text_stream(self):
+        for c in self._chunks:
+            yield c
+
+    @property
+    def text_stream(self):
+        return self._text_stream()
+
+    async def get_final_message(self):
+        return self._final
+
+
+@pytest.mark.asyncio
+async def test_anthropic_streaming_uses_real_usage_for_input_tokens(monkeypatch):
+    import anthropic
+
+    fake_final = _FakeFinalMessage(usage=_FakeUsage(input_tokens=999, output_tokens=3))
+
+    class _FakeMessages:
+        def stream(self, **kwargs):
+            # A system prompt reaching the SDK call is exactly what the old
+            # local estimate (count_messages_tokens(conv, ...)) dropped —
+            # `conv` never includes it.
+            assert "system" in kwargs
+            return _FakeMessageStream(["Hel", "lo"], fake_final)
+
+    class _FakeClient:
+        def __init__(self, api_key=None):
+            self.messages = _FakeMessages()
+
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", _FakeClient)
+
+    provider = AnthropicProvider(api_key="test-key")
+    resp = await provider._call(
+        messages=[{"role": "user", "content": "hi"}],
+        model="claude-sonnet-4-6",
+        max_tokens=100,
+        stream=True,
+        system="You are a helpful assistant. " * 200,
+    )
+
+    assert resp.text == "Hello"
+    # 999 is nowhere near what a local estimate of the tiny "hi" message
+    # alone would produce — this can only come from the real usage object,
+    # proving the system prompt's tokens are no longer silently dropped.
+    assert resp.input_tokens == 999
+    assert resp.output_tokens == 3
+    assert resp.finish_reason == "end_turn"
+
+
+@dataclass
+class _FakeGeminiUsage:
+    prompt_token_count: int
+    candidates_token_count: int
+
+
+class _FakeGeminiResponse:
+    def __init__(self, text: str, usage: _FakeGeminiUsage):
+        self.text = text
+        self.usage_metadata = usage
+
+
+class _FakeChat:
+    def __init__(self, response: _FakeGeminiResponse):
+        self._response = response
+
+    async def send_message_async(self, *args, **kwargs):
+        return self._response
+
+
+class _FakeGenerativeModel:
+    def __init__(self, response: _FakeGeminiResponse, **kwargs):
+        self._response = response
+        # Constructor is called with system_instruction=... when a system
+        # prompt is present — the bug this test guards against is that
+        # system_instruction's tokens never made it into input_tokens.
+        self.received_kwargs = kwargs
+
+    def start_chat(self, history=None):
+        return _FakeChat(self._response)
+
+
+@pytest.mark.asyncio
+async def test_gemini_uses_real_usage_metadata_for_input_tokens(monkeypatch):
+    genai = pytest.importorskip("google.generativeai")
+
+    fake_response = _FakeGeminiResponse(
+        text="hi there",
+        usage=_FakeGeminiUsage(prompt_token_count=1234, candidates_token_count=7),
+    )
+    fake_model = _FakeGenerativeModel(fake_response)
+
+    monkeypatch.setattr(genai, "configure", lambda **kw: None)
+    monkeypatch.setattr(genai, "GenerativeModel", lambda *a, **kw: fake_model)
+
+    provider = GeminiProvider(api_key="test-key")
+    resp = await provider._call(
+        messages=[{"role": "user", "content": "hi"}],
+        model="gemini-1.5-pro",
+        max_tokens=100,
+        stream=False,
+        system="You are a helpful assistant. " * 200,
+    )
+
+    assert resp.text == "hi there"
+    # 1234 is nowhere near a local estimate of "hi" alone — only the real
+    # usage_metadata (which naturally includes system_instruction) gives
+    # this figure, proving the fallback local estimate wasn't used.
+    assert resp.input_tokens == 1234
+    assert resp.output_tokens == 7

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -139,6 +139,31 @@ class TestRedaction:
         cleaned = redact_messages(messages)  # must not raise
         assert "sk-proj" not in cleaned[0]["content"][1]
 
+    def test_tool_result_with_nested_list_content_is_redacted(self):
+        """FIXED BUG: a tool_result block's `content` is `str | list[block]`
+        per the Anthropic/OpenAI schema — a tool returning structured output
+        (e.g. a file-read result) commonly shapes it as
+        [{"type": "text", "text": ...}], not a bare string. The old code
+        only redacted block["content"] when it was a str, so a secret
+        embedded in a tool_result's nested list content passed straight
+        through to the graph, checkpoints, and the background extraction
+        LLM — silently, with no error and no test catching it."""
+        messages = [{
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": [
+                    {"type": "text", "text": "file contents: sk-ant-api03-"
+                     "abcdefghij1234567890-ABCDEFGHIJ1234567890KLMNOP"},
+                ],
+            }],
+        }]
+        cleaned = redact_messages(messages)
+        nested_text = cleaned[0]["content"][0]["content"][0]["text"]
+        assert "sk-ant" not in nested_text
+        assert "[REDACTED]" in nested_text
+
     # ── URL-embedded credentials and additional provider key formats ────────
 
     def test_connection_string_password_redacted(self):

--- a/tokenmizer/cli.py
+++ b/tokenmizer/cli.py
@@ -353,5 +353,22 @@ def resume(
     ))
 
 
+@app.command()
+def mcp():
+    """Run the MCP stdio server (same entrypoint as `tokenmizer-mcp`).
+
+    Registries that install a pypi package and invoke it by the package's
+    own name (`uvx tokenmizer`, `pip install tokenmizer && tokenmizer`)
+    reach this CLI, not the separate `tokenmizer-mcp` console script — the
+    MCP server.json schema has no field to point them at a differently
+    named entry point (see server.json's `packageArguments`, which passes
+    `mcp` to land here). Without this subcommand, a registry using that
+    convention got Typer's usage text instead of an MCP JSON-RPC
+    handshake and treated the server as broken.
+    """
+    from tokenmizer.mcp.server import run_stdio_server
+    run_stdio_server()
+
+
 if __name__ == "__main__":
     app()

--- a/tokenmizer/providers/providers.py
+++ b/tokenmizer/providers/providers.py
@@ -215,15 +215,25 @@ class AnthropicProvider(BaseProvider):
 
             if stream:
                 full_text = ""
-                input_tokens = count_messages_tokens(conv, model)
                 async with client.messages.stream(
                     model=model, messages=conv, max_tokens=max_tokens, **kwargs_clean
                 ) as s:
                     async for chunk in s.text_stream:
                         full_text += chunk
-                output_tokens = count_tokens(full_text, model)
-                return LLMResponse(text=full_text, input_tokens=input_tokens,
-                                   output_tokens=output_tokens, model=model, provider="anthropic")
+                    # Real API-reported usage, not a local estimate — the
+                    # estimate this replaced counted `conv` only (Anthropic
+                    # takes system as a separate top-level param, stripped
+                    # out of `conv` above) and never added the system
+                    # prompt's tokens back in, silently undercounting
+                    # input_tokens for every streamed call with a system
+                    # prompt. The non-streaming branch below already uses
+                    # resp.usage for the same reason.
+                    final = await s.get_final_message()
+                return LLMResponse(text=full_text,
+                                   input_tokens=final.usage.input_tokens,
+                                   output_tokens=final.usage.output_tokens,
+                                   model=model, provider="anthropic",
+                                   finish_reason=final.stop_reason or "stop")
 
             resp = await client.messages.create(
                 model=model, messages=conv, max_tokens=max_tokens, **kwargs_clean
@@ -497,8 +507,23 @@ class GeminiProvider(BaseProvider):
                 generation_config=genai.GenerationConfig(**gen_kw),
             )
             text = resp.text or ""
-            input_tokens = count_messages_tokens(conversation, model)
-            output_tokens = count_tokens(text, model)
+            # Real API-reported usage when the SDK provides it.
+            # prompt_token_count is the full effective prompt size
+            # (Google's own docs: "includes ... cached content"), so unlike
+            # the local estimate below it correctly counts
+            # system_instruction — which lives outside `conversation` here
+            # the same way Anthropic's system param lives outside `conv`,
+            # and was silently missing from every token count that used
+            # to fall back to count_messages_tokens(conversation, model)
+            # unconditionally, undercounting input_tokens on every call
+            # that set a system prompt.
+            usage = getattr(resp, "usage_metadata", None)
+            if usage is not None and usage.prompt_token_count:
+                input_tokens = usage.prompt_token_count
+                output_tokens = usage.candidates_token_count
+            else:
+                input_tokens = count_messages_tokens(conversation, model)
+                output_tokens = count_tokens(text, model)
             return LLMResponse(
                 text=text,
                 input_tokens=input_tokens,

--- a/tokenmizer/security/redaction.py
+++ b/tokenmizer/security/redaction.py
@@ -118,10 +118,21 @@ def _redact_content(content):
             elif isinstance(block, dict):
                 if block.get("type") == "text" and "text" in block:
                     cleaned.append({**block, "text": redact(str(block["text"]))})
-                elif "content" in block and isinstance(block.get("content"), str):
-                    cleaned.append({**block, "content": redact(block["content"])})
+                elif "content" in block and isinstance(block.get("content"), (str, list)):
+                    # tool_result content is `str | list[block]` per the
+                    # Anthropic/OpenAI schema — a tool returning structured
+                    # output (e.g. a file-read result) commonly shapes it as
+                    # [{"type": "text", "text": ...}], not a bare string. The
+                    # str-only check this replaced left that list branch
+                    # matching neither this arm nor "leave untouched" for a
+                    # good reason, silently passing a secret embedded in a
+                    # tool result straight through to the graph, checkpoints,
+                    # and the background extraction LLM. Recursing through
+                    # _redact_content (which already handles both shapes)
+                    # covers it the same way the top-level list does.
+                    cleaned.append({**block, "content": _redact_content(block["content"])})
                 else:
-                    # image/document/tool_use/tool_result blocks — leave untouched
+                    # image/document/tool_use blocks — leave untouched
                     cleaned.append(block)
             else:
                 cleaned.append(block)


### PR DESCRIPTION
## What this PR does

Codebase audit. Four real bugs found and fixed, each with a regression test.

### 1. Registry-launched MCP server was unreachable (likely Glama's actual build failure)

`server.json` declares the pypi package `identifier` as `tokenmizer`, with no field to name a different entry point (confirmed against the MCP `server.schema.json` — `packageArguments`/`runtimeArguments` configure an already-known binary, they don't select which one). Any registry-style launcher that installs the package and runs it by that identifier alone (`uvx tokenmizer`, or `tokenmizer` after `pip install tokenmizer`) lands on the **CLI** console script (`tokenmizer.cli:app`), not the MCP server (`tokenmizer-mcp` → `tokenmizer.mcp.server:run_stdio_server`). With no arguments, that CLI prints a "Missing command" usage error and exits — no MCP handshake, so any directory that spins up the server this way to introspect its tools sees a broken build. README's own `.mcp.json` setup was unaffected — only identifier-as-command launchers hit this.

**Fix:** added an `mcp` subcommand to `tokenmizer/cli.py` dispatching to the same `run_stdio_server()`, and `packageArguments: ["mcp"]` in `server.json` so a convention-following launcher runs `tokenmizer mcp` and reaches it. Verified manually: before, bare `tokenmizer` errored; after, `tokenmizer mcp` correctly answers `tools/list` over stdio.

### 2 & 3. Silent token-count undercounts (providers.py was 20% covered, zero dedicated tests)

- `AnthropicProvider._call()`'s buffered-streaming branch (`chat(..., stream=True)`, a documented public parameter) computed `input_tokens` from a local estimate over `conv`, which has the system message stripped out (Anthropic takes it as a separate param). Nothing added those tokens back — silently undercounted. Fixed by reading real usage from `get_final_message()`, same as the non-streaming branch already does via `resp.usage`.
- `GeminiProvider._call()` — same bug class, but on the path used by **every** Gemini call: always used a local estimate excluding `system_instruction`, even though the SDK's response exposes real `usage_metadata` (whose `prompt_token_count` is documented as the full effective prompt size). Now uses `usage_metadata` when present, estimate as fallback only.

Both silently corrupted the token-savings/cost analytics that are this project's core value proposition — no error, no log line, just a wrong number.

### 4. Redaction gap: secrets inside nested `tool_result` content survived

`security/redaction.py`'s `_redact_content()`: a `tool_result` block's `content` is `str | list[block]` per the Anthropic/OpenAI schema — a tool returning structured output (e.g. a file-read result) commonly shapes it as `[{"type": "text", "text": ...}]`, not a bare string. The old code only redacted `block["content"]` when it was a `str`, so a secret embedded in a tool_result's **nested list** content (e.g. an API key inside file contents a tool returned) passed straight through to the graph, checkpoints, and the background extraction LLM — the exact leak this module's own docstring says it exists to prevent. Confirmed with a live `sk-ant-...` key round-tripped unredacted before the fix. Now recurses through `_redact_content`, which already handles both shapes.

### Also swept, no changes needed
Bare `except: pass`, `print()` debug leftovers, mutable default args, misused `assert`, TODO/FIXME debt, `main` vs PyPI release drift — all clean. `tokenmizer/storage/__init__.py` and `state/backend.py` are unused but already documented as intentional in `CONTRIBUTING.md`'s "Reality" table, not silent dead code.

Added `tests/unit/test_providers.py` (previously nonexistent), a regression test in `test_security.py`, and `google-generativeai` to the `dev` extra so the Gemini test actually runs in CI instead of skipping.

No release is being cut for this — normal PR, releases reserved for major changes.

## Type
- [x] Bug fix
- [ ] Extraction improvement (graph_memory/)
- [ ] New provider
- [ ] Performance
- [ ] Documentation

## Tests
- [x] `pytest tests/ -v` passes (610 passed)
- [x] `ruff check tokenmizer/` clean
- [ ] Memory accuracy test added/updated (if extraction change) — n/a

## Checklist
- [x] No raw dicts crossing layer boundaries (use DTOs)
- [x] No `os.getenv()` outside `config/settings.py`
- [x] External imports are lazy (inside functions, with try/except ImportError)