### PR TITLE
Fix intermittent segfault in CI's MCP e2e check

### DIFF
--- a/scripts/mcp_e2e_check.py
+++ b/scripts/mcp_e2e_check.py
@@ -30,8 +30,16 @@ def check(name: str, cond: bool, detail: str = ""):
         FAILURES.append(name)
 
 
-def _start_proxy_in_thread(port: int) -> None:
-    """Run the real FastAPI app via uvicorn in a daemon thread."""
+def _start_proxy_in_thread(port: int):
+    """Run the real FastAPI app via uvicorn in a daemon thread.
+
+    Returns (server, thread) so the caller can shut the server down and
+    join the thread before the process exits. Left running, the daemon
+    thread still owns a live asyncio event loop (uvloop, under
+    uvicorn[standard] on Linux) when CPython starts finalizing modules —
+    a known source of segfaults during interpreter shutdown, since the
+    loop's C-level state can be torn down out from under it mid-iteration.
+    """
     import threading
     import time
 
@@ -45,9 +53,14 @@ def _start_proxy_in_thread(port: int) -> None:
     t.start()
     for _ in range(50):  # wait up to 5s for startup
         if server.started:
-            return
+            return server, t
         time.sleep(0.1)
     raise RuntimeError("proxy did not start within 5s")
+
+
+def _stop_proxy(server, thread) -> None:
+    server.should_exit = True
+    thread.join(timeout=5)
 
 
 def _seed_session_graph(session_id: str) -> None:
@@ -69,7 +82,7 @@ def _seed_session_graph(session_id: str) -> None:
 def main() -> int:
     port = 8765
     _seed_session_graph("mcp-e2e-test")
-    _start_proxy_in_thread(port)
+    server, server_thread = _start_proxy_in_thread(port)
     os.environ["TOKENMIZER_URL"] = f"http://127.0.0.1:{port}"
     print(f"proxy up on :{port}")
 
@@ -162,6 +175,13 @@ def main() -> int:
     finally:
         proc.stdin.close()
         proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+        _stop_proxy(server, server_thread)
 
     print()
     if FAILURES:


### PR DESCRIPTION
## What this PR does

CI run [31711895913](https://github.com/Shweta-Mishra-ai/tokenmizer/actions/runs/31711895913) failed on `main` with a segfault (exit 139) in `scripts/mcp_e2e_check.py`, right after the script's own checks had all printed `[PASS]` — a crash during interpreter shutdown, not a logic failure.

Root cause: `_start_proxy_in_thread()` runs the proxy's real `uvicorn.Server` in a daemon thread but never shuts it down. `main()` returned with that thread — and its live `uvloop` event loop (`uvicorn[standard]` pulls in `uvloop` on Linux, confirmed present in the CI venv) — still running. CPython can then start finalizing modules while the loop's C-level state is mid-iteration on another thread, a known segfault trigger for asyncio/uvloop in a daemon thread at interpreter exit. The MCP subprocess was also only `terminate()`d, never waited on.

Fix: `_start_proxy_in_thread` now returns `(server, thread)`; `main()`'s `finally` block sets `server.should_exit = True` and joins the thread (with a timeout), and waits on the subprocess with a `kill()` fallback, before returning.

I checked prior CI history: this exact script passed on every run on `main` going back at least 15 runs — this was the first failure, and I couldn't reproduce the segfault locally in 13 runs either before or after the fix, consistent with a timing-dependent race rather than a deterministic bug in the recent regex/vocabulary changes (`patterns.py`/`hybrid_extractor.py`), which I also reviewed and are unrelated (pure Python regex, no threading). The fix removes the actual unsafe pattern regardless of whether it reproduces on demand.

## Type
- [x] Bug fix

## Tests
- [x] `pytest tests/ -v` passes (647/647)
- [x] `ruff check` clean
- [x] `scripts/mcp_e2e_check.py` run manually multiple times, exit 0 each time

## Checklist
- [x] No raw dicts crossing layer boundaries (unaffected — CI script only)
- [x] No `os.getenv()` outside `config/settings.py` (unaffected)
- [x] External imports are lazy (unaffected — no new imports)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5d649QKEyLNBuCAGbraEH)_