### PR TITLE
Pre-launch audit: verify 0.5.4's benchmark fix, close test gaps, sync docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ continuation (`halting`, `blocking`, `breaking`, `rejecting`,
 symptom named mid-sentence ("a deadlock between the two mutexes...")
 keeps its qualifying clause instead of stopping at the first noun.
 
+### Verified — the external benchmark re-scored 0.5.4 after this fix
+This entry originally shipped with no external confirmation that the
+fixes above actually helped — only that they didn't regress this repo's
+own eval corpus, which doesn't contain the gaps they targeted.
+`tokenmizer-research` has since re-run its 100-session benchmark against
+0.5.4: decisions went 50% → **59%** F1 and errors 36% → **44%** F1
+(comparison methods: 65% and 66%). Macro F1 across all categories is now
+**60%**, tying for first among all 8 methods scored (Mem0-style 60%,
+Graphiti-style 59%, GraphRAG-style 44%, MemGPT-style 35%, naive
+baselines ≤20%). Decisions and errors remain the weakest categories
+relative to the two methods TokenMizer ties overall — real progress, not
+yet parity.
+
 ## [0.5.3] — 2026-08-12 — registry MCP launch, memory improvements, and a stored-XSS fix
 
 A codebase audit that grew from three fixes into ten, each with a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ tokenmizer/
 │   ├── graph_retrieval/          # category recall
 │   ├── persistence/              # write amplification + concurrency
 │   └── latency/                  # end-to-end proxy latency (needs a running server)
-└── tests/                        # 47 files, 639 tests — see TESTING.md for how to run them
+└── tests/                        # 49 files, 664 tests — see TESTING.md for how to run them
 ```
 
 ---
@@ -312,7 +312,7 @@ pytest tests/ -v                                # full suite
 pytest tests/unit/test_decision_tracker.py -v   # a single module
 pytest tests/memory_accuracy/ -v                # extraction-accuracy regression
 python scripts/mcp_e2e_check.py                 # MCP stdio transport, end to end
-pytest tests/ --cov=tokenmizer --cov-report=term-missing   # coverage report (no enforced floor)
+pytest tests/ --cov=tokenmizer --cov-report=term-missing   # coverage report (50% floor enforced, see pyproject.toml)
 
 ### Changing extraction
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,17 @@ than real transcripts and a single headline hides that: **synthetic 95%,
 real 90%.** Treat 90% as the number that describes real sessions. n=14
 is a small sample and the same person wrote every label.
 
+**Independently verified against 7 other methods.** A separate
+100-session benchmark ([tokenmizer-research](https://github.com/Shweta-Mishra-ai/tokenmizer-research),
+a different corpus and scorer than the numbers above) ties TokenMizer
+0.5.4 for first place at **60% macro F1** — level with Mem0-style (60%)
+and Graphiti-style (59%), ahead of GraphRAG-style (44%), MemGPT-style
+(35%), and every naive baseline (≤20%). Decisions and errors are still
+its weakest categories relative to the two methods it ties overall —
+59%/44% F1 against 65%/66% for Graphiti/Mem0-style, up from 50%/36% in
+0.5.3 after a fix (see [CHANGELOG](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/CHANGELOG.md))
+targeted at the specific gaps that benchmark found.
+
 → [**Benchmarks**](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/benchmarks.md) — memory quality against a
 plain-summary baseline, storage, and how to score your own sessions.
 
@@ -308,7 +319,7 @@ here rather than left to be discovered:
 git clone https://github.com/Shweta-Mishra-ai/tokenmizer
 cd tokenmizer
 pip install -e ".[dev]"
-pytest tests/ -q && ruff check tokenmizer/     # 639 tests, must stay green
+pytest tests/ -q && ruff check tokenmizer/     # 664 tests, must stay green
 ```
 
 **The most valuable contribution is a session where extraction got it

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,12 +1,12 @@
 # Testing
 
-The suite is 639 tests under `pytest`, and it is the source of truth —
+The suite is 664 tests under `pytest`, and it is the source of truth —
 if a claim elsewhere in the docs disagrees with what the suite does, the
 suite is right and the docs are a bug.
 
 ```bash
 pip install -e ".[dev]"
-pytest tests/ -v              # 639 tests
+pytest tests/ -v              # 664 tests
 ruff check tokenmizer/ tests/ # lint, import order
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,7 +237,7 @@ from tokenmizer.filters.file_intelligence import FileIntelligence
 fi = FileIntelligence()
 result = fi.process(open("sales.csv","rb").read(), "sales.csv",
                     token_budget=500, query="which regions underperforming")
-# 412,000 tokens → 447 tokens  (99.9% saved)
+# 400,000 tokens → 450 tokens  (99.9% saved)
 ```
 
 | File | Savings |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -10,7 +10,7 @@ python -m benchmarks.eval --errors                   # every miss, every false p
 python -m benchmarks.eval --corpus DIR               # score YOUR sessions
 python -m benchmarks.checkpoint_accuracy.runner_v2   # graph vs summary
 python -m benchmarks.persistence.runner              # storage + concurrency
-pytest tests/ -q                                     # 639 tests
+pytest tests/ -q                                     # 664 tests
 ```
 
 ## Extraction quality — precision, recall and F1

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -32,9 +32,9 @@ other two rather than competing with them.
 |---|---|
 | **v0.3** | SSE streaming passthrough (checkpoint on stream close) |
 | **v0.4** | Graph ontology · deterministic reasoning API (`why`, `impact`, consistency checks) |
-| **v0.5** | Per-row storage schema · cross-process write safety · session ownership · durability guarantees · measured extraction quality *(this release)* |
-| v0.6 | Cross-session memory · embedding-based edge linking · LLM-assisted extraction for the defects regexes cannot reach |
-| Research | Real-transcript benchmark suite → paper ([tokenmizer-research](https://github.com/Shweta-Mishra-ai/tokenmizer-research)) |
+| **v0.5** | Per-row storage schema · cross-process write safety · session ownership · durability guarantees · embedding-based semantic recall and conflict/dedup matching · measured extraction quality *(this release)* |
+| v0.6 | Cross-session memory · LLM-assisted extraction for the defects regexes cannot reach |
+| Research | 100-session, 8-method benchmark → paper ([tokenmizer-research](https://github.com/Shweta-Mishra-ai/tokenmizer-research)) — TokenMizer 0.5.4 ties for first at 60% macro F1, level with Mem0-style and Graphiti-style |
 
 Have a use case that doesn't fit? [Open an issue](https://github.com/Shweta-Mishra-ai/tokenmizer/issues/new/choose) — extraction misses have their own issue template.
 

--- a/tests/js/dashboard_auth.test.mjs
+++ b/tests/js/dashboard_auth.test.mjs
@@ -1,0 +1,141 @@
+// Behavioral tests for the dashboard's client-side auth retry logic
+// (getStoredApiKey/authOptions/requestApiKey/dashboardFetch), extracted
+// verbatim from the real DASHBOARD_HTML string and executed in a Node vm
+// context with mocked sessionStorage/window.prompt/fetch.
+//
+// Closes GitHub issue #36: the existing Python test
+// (tests/unit/test_dashboard.py) only asserts that certain substrings
+// appear in DASHBOARD_HTML — it would still pass if the logic inside
+// those functions were subtly wrong, as long as the right tokens were
+// present somewhere in the file. This file actually runs the shipped
+// code and checks its behavior for the three paths the issue named:
+// concurrent 401s sharing one prompt, a cancelled prompt staying
+// dismissed for the rest of the session, and a stale stored key being
+// dropped before re-prompting.
+//
+// Run directly: node tests/js/dashboard_auth.test.mjs
+// Wired into the suite via tests/unit/test_dashboard_auth_js.py, which
+// skips (not fails) if `node` isn't on PATH.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import vm from 'node:vm';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pagePyPath = path.join(__dirname, '../../tokenmizer/dashboard/page.py');
+const pageSrc = readFileSync(pagePyPath, 'utf8');
+
+const scriptStart = pageSrc.indexOf('const API_KEY_STORAGE_KEY');
+const scriptEnd = pageSrc.indexOf('async function loadStats');
+assert.ok(scriptStart !== -1 && scriptEnd !== -1 && scriptEnd > scriptStart,
+  'could not locate the auth-retry block in tokenmizer/dashboard/page.py — ' +
+  'has DASHBOARD_HTML been restructured?');
+const authScript = pageSrc.slice(scriptStart, scriptEnd);
+
+/**
+ * Builds a fresh vm context with mocked sessionStorage/window/fetch and
+ * the real dashboardFetch/requestApiKey/getStoredApiKey/authOptions
+ * loaded into it. Each test gets its own context so module-level state
+ * (apiKeyPrompt, apiKeyPromptDismissed) never leaks between tests.
+ */
+function makeContext({ promptResponses = [], responses = [] } = {}) {
+  const store = new Map();
+  const fetchCalls = [];
+  const promptCalls = { count: 0 };
+  let responseIdx = 0;
+
+  const sandbox = {
+    sessionStorage: {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, v),
+      removeItem: (k) => store.delete(k),
+    },
+    window: {
+      prompt: (msg) => {
+        const value = promptResponses[promptCalls.count];
+        promptCalls.count += 1;
+        return value === undefined ? null : value;
+      },
+    },
+    fetch: (fetchPath, opts) => {
+      fetchCalls.push({ path: fetchPath, opts });
+      const status = responses[Math.min(responseIdx, responses.length - 1)];
+      responseIdx += 1;
+      return Promise.resolve({ status, ok: status >= 200 && status < 300 });
+    },
+    console,
+  };
+  const context = vm.createContext(sandbox);
+  vm.runInContext(authScript, context);
+  return { context, store, fetchCalls, promptCalls };
+}
+
+test('stale-key path: a stored key that gets 401 is removed before re-prompting, and the retry uses the new key', async () => {
+  const { context, store, fetchCalls, promptCalls } = makeContext({
+    promptResponses: ['new-key'],
+    responses: [401, 200],
+  });
+  store.set('tokenmizer.apiKey', 'old-key');
+
+  const result = await vm.runInContext("dashboardFetch('/api/stats')", context);
+
+  assert.equal(promptCalls.count, 1, 'expected exactly one prompt for the stale key');
+  assert.equal(fetchCalls.length, 2, 'expected an initial fetch plus one retry');
+  assert.equal(fetchCalls[0].opts.headers.Authorization, 'Bearer old-key');
+  assert.equal(fetchCalls[1].opts.headers.Authorization, 'Bearer new-key',
+    'retry must use the freshly-prompted key, not the stale one');
+  assert.equal(store.get('tokenmizer.apiKey'), 'new-key',
+    'the stale key must be gone from storage, replaced by the new one');
+  assert.equal(result.status, 200);
+});
+
+test('concurrent-401 path: two requests that both 401 at once share a single prompt', async () => {
+  const { context, fetchCalls, promptCalls } = makeContext({
+    promptResponses: ['shared-key'],
+    responses: [401, 401, 200, 200],
+  });
+
+  const [a, b] = await vm.runInContext(
+    "Promise.all([dashboardFetch('/api/stats'), dashboardFetch('/api/cache/stats')])",
+    context
+  );
+
+  assert.equal(promptCalls.count, 1,
+    `two concurrent 401s must share one prompt, got ${promptCalls.count} prompts`);
+  assert.equal(fetchCalls.length, 4, 'each request retries once after the shared prompt resolves');
+  assert.equal(a.status, 200);
+  assert.equal(b.status, 200);
+});
+
+test('cancel path: dismissing the prompt once suppresses prompting for the rest of the session', async () => {
+  const { context, fetchCalls, promptCalls } = makeContext({
+    promptResponses: [''], // user cancels / submits empty
+    responses: [401, 401],
+  });
+
+  const first = await vm.runInContext("dashboardFetch('/api/stats')", context);
+  assert.equal(first.status, 401, 'no retry happens when the user cancels — the original 401 is returned');
+  assert.equal(promptCalls.count, 1);
+
+  const second = await vm.runInContext("dashboardFetch('/api/cache/stats')", context);
+  assert.equal(second.status, 401);
+  assert.equal(promptCalls.count, 1,
+    'a later 401 in the same session must not prompt again after a cancel');
+  assert.equal(fetchCalls.length, 2,
+    'neither call retries — a dismissed prompt must not trigger a fetch with a key that was never obtained');
+});
+
+test('no-401 path: dashboardFetch does not prompt or retry when the response is not 401', async () => {
+  const { fetchCalls, promptCalls, context } = makeContext({
+    responses: [200],
+  });
+
+  const result = await vm.runInContext("dashboardFetch('/api/stats')", context);
+
+  assert.equal(result.status, 200);
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(promptCalls.count, 0);
+});

--- a/tests/unit/test_benchmark_gap_fixes.py
+++ b/tests/unit/test_benchmark_gap_fixes.py
@@ -1,0 +1,152 @@
+"""
+Regression tests for the fixes in CHANGELOG's [0.5.4] entry ("decision
+and error extraction, targeted at an external benchmark").
+
+That release shipped four specific fixes — a question-context guard, two
+vocabulary additions for decisions, and one for errors — verified only
+by confirming the repo's own 14-session eval corpus did not regress
+(90%/95% decisions, 93%/96% errors unchanged). That corpus does not
+contain the gaps the fixes target, so nothing before this file actually
+exercised the new code paths: zero tests referenced
+`_is_question_context`, "leaning toward"/"recommend", the new tech
+whitelist entries, or the new error vocabulary. A regex change with no
+test asserting its own behavior is exactly the kind of unverified fix
+this project's own audit history flags elsewhere (see
+test_negation_scope.py, whose template this file follows).
+"""
+from __future__ import annotations
+
+from tokenmizer.graph_memory.hybrid_extractor import HybridExtractor
+from tokenmizer.graph_memory.patterns import _is_question_context
+
+extractor = HybridExtractor(min_confidence=0.50)
+
+
+def _decision_labels(messages):
+    return [d.get("label", "") for d in extractor.heuristic_extract(messages).decisions]
+
+
+def _errors(messages):
+    return extractor.heuristic_extract(messages).errors
+
+
+class TestQuestionContextGuard:
+    """The bug this shipped to fix: a question weighing options was
+    recorded as a decision made, because the negation guard only looks
+    backward for words like "not" and a question has none."""
+
+    def test_is_question_context_true_when_clause_ends_in_question_mark(self):
+        content = "Should we go with Postgres for this?"
+        # match_start at "go with" (index of "go")
+        idx = content.index("go with")
+        assert _is_question_context(content, idx) is True
+
+    def test_is_question_context_false_for_a_statement(self):
+        content = "We are going with Postgres for this."
+        idx = content.index("going with")
+        assert _is_question_context(content, idx) is False
+
+    def test_is_question_context_scoped_to_current_clause_not_next(self):
+        # The match's own clause is a statement; a LATER clause happens to
+        # end in "?" — that must not retroactively suppress this match.
+        content = "We are going with Postgres. Does that work for you?"
+        idx = content.index("going with")
+        assert _is_question_context(content, idx) is False
+
+    def test_question_weighing_postgres_or_redis_yields_no_decision(self):
+        messages = [{
+            "role": "user",
+            "content": "Should we go with Postgres or is Redis better for this?",
+        }]
+        labels = _decision_labels(messages)
+        assert not any("postgres" in label.lower() or "redis" in label.lower()
+                        for label in labels), (
+            f"a question weighing options was extracted as a decision: {labels}"
+        )
+
+    def test_decision_header_format_also_respects_question_guard(self):
+        messages = [{"role": "user", "content": "Decided: should we use Kafka?"}]
+        labels = _decision_labels(messages)
+        assert not any("kafka" in label.lower() for label in labels), (
+            f"a question-form 'Decided:' header was extracted as a decision: {labels}"
+        )
+
+    def test_real_decision_after_a_question_is_still_extracted(self):
+        """The guard must not become a blanket suppressor — a genuine
+        decision in its own (non-question) clause still needs to fire."""
+        messages = [{
+            "role": "user",
+            "content": "Should we use Postgres? Yes — decided: going with Postgres.",
+        }]
+        labels = _decision_labels(messages)
+        assert any("postgres" in label.lower() for label in labels), (
+            f"the question guard suppressed a real decision in a later clause: {labels}"
+        )
+
+
+class TestNewDecisionVocabulary:
+    """New trigger verbs ('leaning toward', 'recommend(ed/s)') and new
+    tech-name whitelist entries the benchmark's missed-items list named."""
+
+    def test_leaning_toward_is_a_decision_trigger(self):
+        messages = [{"role": "user", "content": "Leaning toward using dbt for transforms."}]
+        labels = _decision_labels(messages)
+        assert any("dbt" in label.lower() for label in labels), (
+            f"'leaning toward' + new tech name 'dbt' not extracted: {labels}"
+        )
+
+    def test_recommends_is_a_decision_trigger(self):
+        messages = [{"role": "user", "content": "The team recommends sqlc for the query layer."}]
+        labels = _decision_labels(messages)
+        assert any("sqlc" in label.lower() for label in labels), (
+            f"'recommends' + new tech name 'sqlc' not extracted: {labels}"
+        )
+
+    def test_recommended_past_tense_is_a_decision_trigger(self):
+        messages = [{"role": "user", "content": "Airflow was recommended for orchestration."}]
+        labels = _decision_labels(messages)
+        assert any("airflow" in label.lower() for label in labels), (
+            f"past-tense 'recommended' + new tech name 'airflow' not extracted: {labels}"
+        )
+
+    def test_new_tech_whitelist_entries_are_recognized(self):
+        for tech in ["sqlc", "dbt", "nats", "pnpm", "uv", "ruff", "kong", "airflow"]:
+            messages = [{"role": "user", "content": f"Going with {tech} for this."}]
+            labels = _decision_labels(messages)
+            assert any(tech in label.lower() for label in labels), (
+                f"new whitelist tech name {tech!r} was not extracted as a decision: {labels}"
+            )
+
+
+class TestNewErrorVocabulary:
+    """Expanded error-symptom vocabulary and wider trailing-context
+    capture from the same release."""
+
+    def test_nil_pointer_dereference_is_extracted(self):
+        messages = [{"role": "user", "content": "Hit a nil pointer dereference in the handler."}]
+        errors = _errors(messages)
+        assert any("nil pointer" in e.lower() for e in errors), f"got: {errors}"
+
+    def test_thundering_herd_is_extracted(self):
+        messages = [{"role": "user", "content": "We're seeing a thundering herd on cache expiry."}]
+        errors = _errors(messages)
+        assert any("thundering herd" in e.lower() for e in errors), f"got: {errors}"
+
+    def test_symptom_with_between_clause_keeps_the_qualifying_context(self):
+        messages = [{
+            "role": "user",
+            "content": "There's a deadlock between the two mutexes during shutdown.",
+        }]
+        errors = _errors(messages)
+        assert any("deadlock" in e.lower() and "mutex" in e.lower() for e in errors), (
+            f"the wider trailing-context capture (between-clause) dropped the "
+            f"qualifying detail: {errors}"
+        )
+
+    def test_symptom_with_gerund_continuation_keeps_the_qualifying_context(self):
+        messages = [{
+            "role": "user",
+            "content": "Consumer lag is growing unbounded on the ingest topic.",
+        }]
+        errors = _errors(messages)
+        assert any("consumer lag" in e.lower() for e in errors), f"got: {errors}"

--- a/tests/unit/test_dashboard_auth_js.py
+++ b/tests/unit/test_dashboard_auth_js.py
@@ -1,0 +1,37 @@
+"""
+Runs tests/js/dashboard_auth.test.mjs — behavioral tests for the
+dashboard's client-side auth-retry logic, executed against the real
+script extracted from DASHBOARD_HTML rather than reimplemented.
+
+See GitHub issue #36: the other dashboard test (test_dashboard.py) only
+asserts that certain substrings are present in the HTML, which a subtly
+wrong implementation would still pass. This shells out to Node (skipping,
+not failing, if it isn't on PATH — mirroring this repo's convention of
+graceful degradation for optional external tooling) to actually execute
+dashboardFetch()/requestApiKey() and verify the concurrent-401, cancel,
+and stale-key paths behave as intended.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_JS_TEST = Path(__file__).parent.parent / "js" / "dashboard_auth.test.mjs"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not on PATH")
+def test_dashboard_auth_behavior():
+    result = subprocess.run(
+        ["node", "--test", str(_JS_TEST)],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+    assert result.returncode == 0, (
+        "dashboard auth JS behavioral tests failed — see stdout/stderr above"
+    )

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -227,3 +227,41 @@ class TestSessionIdIsUrlEncoded:
         captured = self._capture_get_url(monkeypatch)
         mcp.handle_get_graph_stats({"session_id": "session#fragment"})
         assert "session#fragment" not in captured["path"]
+
+
+class TestProxyRequestFailuresAreLogged:
+    """_get/_post returned {"error": str(e)} to the caller on a failed
+    proxy request but never logged anything server-side — a flaky
+    TOKENMIZER_URL connection left zero trace for anyone debugging via
+    server logs, only visible in whatever the MCP client showed the
+    end user."""
+
+    def test_get_logs_a_warning_on_failure(self, monkeypatch, caplog):
+        import httpx as httpx_mod
+
+        def _raise_get(*a, **kw):
+            raise httpx_mod.ConnectError("connection refused")
+        monkeypatch.setattr(httpx_mod, "get", _raise_get)
+
+        with caplog.at_level("WARNING"):
+            result = mcp._get("/api/stats")
+
+        assert "error" in result
+        assert any("connection refused" in rec.message for rec in caplog.records), (
+            f"expected a warning log mentioning the failure, got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_post_logs_a_warning_on_failure(self, monkeypatch, caplog):
+        import httpx as httpx_mod
+
+        def _raise_post(*a, **kw):
+            raise httpx_mod.ConnectError("connection refused")
+        monkeypatch.setattr(httpx_mod, "post", _raise_post)
+
+        with caplog.at_level("WARNING"):
+            result = mcp._post("/api/checkpoint", {})
+
+        assert "error" in result
+        assert any("connection refused" in rec.message for rec in caplog.records), (
+            f"expected a warning log mentioning the failure, got: {[r.message for r in caplog.records]}"
+        )

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -259,9 +259,18 @@ def test_readme_test_count_matches_reality():
 
     text = (ROOT / "README.md").read_text(encoding="utf-8") + "\n".join(
         p.read_text(encoding="utf-8")
-        for p in sorted((ROOT / "docs").glob("*.md")) + [ROOT / "CONTRIBUTING.md"]
+        for p in sorted((ROOT / "docs").glob("*.md"))
+        + [ROOT / "CONTRIBUTING.md", ROOT / "TESTING.md"]
     )
-    quoted = [int(x) for x in re.findall(r'#\s*(\d+) tests', text)]
+    # Not anchored to "#" — CONTRIBUTING.md's tree comment
+    # ("# 48 files, 662 tests") has other words between the marker and
+    # the count, which `#\s*(\d+) tests` never matched, leaving that
+    # line's number free to drift with nothing to catch it. Filtered to
+    # >=100: README's demo transcript says "18 tests passing" about a
+    # fictional example session, not the suite — a real suite-size claim
+    # is always in the hundreds here, so this drops that false match
+    # without re-introducing the anchoring gap above.
+    quoted = [int(x) for x in re.findall(r'(\d+) tests\b', text) if int(x) >= 100]
     assert quoted, "no doc quotes a test count any more — drop this guard too"
 
     for n in quoted:
@@ -424,7 +433,10 @@ def test_internal_markdown_anchors_point_at_real_headings():
     section that was promised.
     """
     docs_dir = ROOT / "docs"
-    scanned = [ROOT / "README.md", *sorted(docs_dir.glob("*.md"))]
+    scanned = [
+        ROOT / "README.md", ROOT / "CONTRIBUTING.md", ROOT / "TESTING.md",
+        *sorted(docs_dir.glob("*.md")),
+    ]
 
     def headings_of(path: Path) -> set[str]:
         text = path.read_text(encoding="utf-8")

--- a/tokenmizer/mcp/server.py
+++ b/tokenmizer/mcp/server.py
@@ -200,6 +200,7 @@ def _get(path: str) -> dict:
     except ImportError:
         return {"error": "pip install httpx  — required for MCP server"}
     except Exception as e:
+        logger.warning(f"GET {path} against the proxy failed: {e}")
         return {"error": str(e)}
 
 
@@ -212,6 +213,7 @@ def _post(path: str, body: dict) -> dict:
     except ImportError:
         return {"error": "pip install httpx  — required for MCP server"}
     except Exception as e:
+        logger.warning(f"POST {path} against the proxy failed: {e}")
         return {"error": str(e)}
 
 


### PR DESCRIPTION
## What this PR does

A final pre-Hacker-News-launch audit: numbers, links, test coverage gaps, and whether 0.5.4's decision/error extraction fix actually helped.

**The headline finding:** 0.5.4's CHANGELOG entry shipped with no external confirmation the fix worked — only that it didn't regress this repo's own eval corpus, which doesn't contain the gaps it targeted. I checked whether `tokenmizer-research` (the external benchmark that found the original gaps) had re-scored 0.5.4, and it has: **decisions 50% → 59% F1, errors 36% → 44% F1**, and TokenMizer now **ties for first place at 60% macro F1** among all 8 methods in that independent 100-session benchmark (level with Mem0-style at 60% and Graphiti-style at 59%, ahead of GraphRAG-style/MemGPT-style/naive baselines). Added this, with sources, to CHANGELOG.md, README.md, and docs/comparisons.md.

Other fixes from the same pass:
- **Zero test coverage on 0.5.4's actual fixes.** Added `tests/unit/test_benchmark_gap_fixes.py` — real regression tests for the question-context guard, new decision trigger verbs/tech whitelist, and new error vocabulary that shipped with no test exercising them at all.
- **Closes #36.** `tests/js/dashboard_auth.test.mjs` + `tests/unit/test_dashboard_auth_js.py`: a Node harness that extracts the real auth-retry script from `DASHBOARD_HTML` and executes it in a `vm` context with mocked `sessionStorage`/`fetch`/`window.prompt`, verifying the concurrent-401 dedup, cancel-dismissal, and stale-key-replacement behavior the existing test only checked for via substring matching. Skips (not fails) if `node` isn't on `PATH`.
- `mcp/server.py`'s `_get`/`_post` now log a warning on a failed proxy request instead of failing completely silently server-side (found by an audit subagent; the only real gap out of ~75 exception sites reviewed).
- Fixed a direct contradiction in CONTRIBUTING.md claiming "no enforced coverage floor" when `pyproject.toml` sets `fail_under=50`.
- Widened `test_version_consistency.py`'s anchor-checker and test-count guards to actually scan `CONTRIBUTING.md`/`TESTING.md`, which they were silently skipping.
- Synced stale test-count references (639 → 664) across README/CONTRIBUTING/TESTING/docs, and a stale worked example in `docs/architecture.md` (412,000/447 → 400,000/450, matching the other two places that same number appears).
- Corrected `docs/comparisons.md`'s roadmap: embedding-based semantic matching already shipped in 0.5.3, it wasn't still pending for v0.6.
- Verified all 6 README contributor-credit PR links (#21, #22, #25, #26, #31, #35) against the real PRs — all genuine, merged, correctly attributed.

## Type
- [x] Bug fix
- [x] Documentation

## Tests
- [x] `pytest tests/ -v` passes (664/664)
- [x] `ruff check tokenmizer/ tests/` clean
- [x] New Node-based dashboard auth test verified directly with `node --test`

## Checklist
- [x] No raw dicts crossing layer boundaries (use DTOs)
- [x] No `os.getenv()` outside `config/settings.py`
- [x] External imports are lazy (inside functions, with try/except ImportError)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5d649QKEyLNBuCAGbraEH)_