### PR TITLE
Fix stale extraction-eval and resume-token numbers in README/docs/CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ An independent 100-session, 8-method benchmark
 weakest categories — decisions (50% F1) and errors (36% F1) — well
 behind two comparison methods (65% and 66%). Every regex above still
 runs on this repo's own 14-session eval corpus (`python -m
-benchmarks.eval`), which stayed at 90%/95% decisions and 93%/96% errors
+benchmarks.eval`), which stayed at 90%/95% decisions and 96%/96% errors
 through this change: that corpus does not contain the specific gaps
 found below, so it is a regression guard here, not the signal that
 found the problem.
@@ -64,6 +64,23 @@ Graphiti-style 59%, GraphRAG-style 44%, MemGPT-style 35%, naive
 baselines ≤20%). Decisions and errors remain the weakest categories
 relative to the two methods TokenMizer ties overall — real progress, not
 yet parity.
+
+### Fixed — the local eval and checkpoint-accuracy numbers were stale, not fabricated
+The intro line above ("93%/96% errors") and README/docs/benchmarks.md's
+extraction table were still quoting a `v0.5.0` run instead of the
+extractor 0.5.4 actually ships: a fresh `python -m benchmarks.eval` gives
+**errors 96%/96% (F1 96%)** and **macro F1 95%** (synthetic 96%, real
+90%), and `--errors` shows 8 misses / 9 spurious against the 172-item
+corpus, not the "four and three" the prose cited. Separately,
+`benchmarks/checkpoint_accuracy/runner_v2.py`'s resume-block average had
+drifted the same way it did once before (see 0.5.0's "249 → 178 tokens"
+entry below): still-quoted 178 tokens is now **161 tokens** (180 / 168 /
+136 across the three sessions). Both were re-measured directly against
+the `v0.5.4` tag, not just current `main`, confirming these numbers were
+already wrong at release rather than drifting afterward. No extraction
+logic changed — this is a docs-only fix. The underlying gap is the same
+one #54 closed for test coverage but not for numbers: nothing in CI ties
+a published figure to the runner that's supposed to produce it.
 
 ## [0.5.3] — 2026-08-12 — registry MCP launch, memory improvements, and a stored-XSS fix
 

--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ of 14 sessions, 6 of them real transcripts:
 |---|---|---|---|
 | Files | 98% | 100% | **99%** |
 | Pending tasks | 100% | 90% | **95%** |
-| Errors | 93% | 96% | **94%** |
+| Errors | 96% | 96% | **96%** |
 | Decisions | 90% | 95% | **92%** |
 | Completed tasks | 92% | 90% | **91%** |
-| | | **macro F1** | **94%** |
+| | | **macro F1** | **95%** |
 
 **Precision is reported, not just recall.** An extractor that emits the
 whole transcript as one node scores 100% recall, which is why
@@ -253,7 +253,7 @@ recall-only extraction numbers should be distrusted — including our own
 earlier ones.
 
 Scored separately by origin, because hand-written fixtures are easier
-than real transcripts and a single headline hides that: **synthetic 95%,
+than real transcripts and a single headline hides that: **synthetic 96%,
 real 90%.** Treat 90% as the number that describes real sessions. n=14
 is a small sample and the same person wrote every label.
 
@@ -286,7 +286,7 @@ Summaries lose structure. You can't query "all superseded decisions" or "what tr
 Mem0 and Zep store *facts* ("user prefers Python"). TokenMizer stores *decisions with rationale* — the full causal chain: what was decided, what replaced it, why, what evidence triggered the change. If you need "remember my name across sessions," use Mem0. If you need "remember that we switched from PostgreSQL to SQLite because of cost, and here's the evidence," use TokenMizer.
 
 **Why not just a longer context window?**
-Longer context means higher cost, slower inference, and attention dilution on long histories. TokenMizer compresses a session into a resume block averaging **178 tokens** (measured, n=3 — see [Benchmarks](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/benchmarks.md)) by extracting what actually matters, not by summarizing.
+Longer context means higher cost, slower inference, and attention dilution on long histories. TokenMizer compresses a session into a resume block averaging **161 tokens** (measured, n=3 — see [Benchmarks](https://github.com/Shweta-Mishra-ai/tokenmizer/blob/main/docs/benchmarks.md)) by extracting what actually matters, not by summarizing.
 
 ## What is not implemented
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,7 +18,7 @@ pytest tests/ -q                                     # 664 tests
 `python -m benchmarks.eval` scores extraction against a labelled corpus:
 **14 sessions, 144 turns, 172 labelled items, 14 domains** (Go, Rust,
 Python, TypeScript, React, SQL, CI, ML, plus six real audit sessions).
-Measured on v0.5.0:
+Measured on v0.5.4:
 
 | Category | Precision | Recall | F1 |
 |---|---|---|---|
@@ -26,8 +26,8 @@ Measured on v0.5.0:
 | Pending tasks | 100% | 90% | **95%** |
 | Decisions | 90% | 95% | **92%** |
 | Completed tasks | 92% | 90% | **91%** |
-| Errors | 93% | 96% | **94%** |
-| | | **macro F1** | **94%** |
+| Errors | 96% | 96% | **96%** |
+| | | **macro F1** | **95%** |
 
 **Precision is reported, not just recall.** An extractor that emits the
 whole transcript as one node scores 100% recall; that is why recall-only
@@ -41,7 +41,7 @@ run rather than kept in a drawer:
 
 | Corpus origin | Sessions | Macro F1 |
 |---|---|---|
-| Synthetic (hand-written) | 8 | **95%** |
+| Synthetic (hand-written) | 8 | **96%** |
 | Real (captured transcripts) | 6 | **90%** |
 
 **Treat 90% as the number that describes real sessions.** The five-point
@@ -66,8 +66,8 @@ author. Label quality, scored separately because a correct-but-sprawling
 label still wastes resume budget: 15% truncated mid-word, 1% spanning more
 than one sentence, mean length 35 characters.
 
-Across 172 labelled items the extractor now misses four and invents
-three. The residue is where regexes genuinely stop: a defect stated as a
+Across 172 labelled items the extractor now misses eight and invents
+nine. The residue is where regexes genuinely stop: a defect stated as a
 measurement ("error recall is 8 percent"), and one failure named twice in
 words that share no tokens ("backfill is timing out" / "the backfill
 timeout"). That is what `use_llm_extraction` is for.
@@ -80,8 +80,8 @@ the format documented in `benchmarks/eval/corpus.py` and run
 
 `benchmarks/checkpoint_accuracy/runner_v2.py`, n=3 synthetic sessions:
 the graph preserves **89%** of labelled information against **79%** for a
-plain-summary baseline (Δ +10%), in an average resume block of **178
-tokens** (197 / 193 / 144 across the three sessions) versus ~1,500+
+plain-summary baseline (Δ +10%), in an average resume block of **161
+tokens** (180 / 168 / 136 across the three sessions) versus ~1,500+
 tokens of raw history. The advantage is concentrated in decision recall
 (92% vs a baseline that drops as low as 50%); on tasks it ties the
 baseline (76% both).


### PR DESCRIPTION
## What this PR does

A follow-up to #54: the extraction-eval and checkpoint-accuracy numbers in README.md and docs/benchmarks.md were still quoting a v0.5.0 run, and the current [0.5.4] CHANGELOG entry's intro line repeated the same stale figure. Re-ran the committed benchmark scripts and corrected every number that had drifted:

| Claim | Was | Actually is |
|---|---|---|
| Errors P/R/F1 | 93% / 96% / 94% | 96% / 96% / 96% |
| Macro F1 | 94% | 95% |
| Synthetic F1 | 95% | 96% |
| Error count on 172-item corpus | "misses four, invents three" | misses 8, invents 9 |
| Checkpoint-accuracy resume avg | 178 tokens (197/193/144) | 161 tokens (180/168/136) |

All other published numbers (decisions/files/pending-tasks rows, the external `tokenmizer-research` 60% macro-F1 comparison, persistence/concurrency figures, the 664 test count, internal links) were checked against a fresh run and are accurate — left untouched.

Checked out the `v0.5.4` tag directly (not just current `main`) before changing anything, to confirm these numbers were wrong at release rather than drifting since. No extraction logic changed anywhere in this diff — docs and CHANGELOG only.

Added a new `### Fixed` subsection to the existing `[0.5.4]` CHANGELOG entry (matching the pattern #54 used for its own late "Verified" addition) explaining the discrepancy and how it was re-measured, rather than silently editing the numbers with no trail.

## Type
- [x] Documentation
- [x] Bug fix (numbers presented as measured facts were incorrect)

## Tests
- [x] `pytest tests/ -q` passes (664/664)
- [x] `ruff check tokenmizer/ tests/ benchmarks/` clean
- [x] Every changed number reproduced with `python -m benchmarks.eval`, `python -m benchmarks.eval --errors`, and `python -m benchmarks.checkpoint_accuracy.runner_v2`, run against both current `main` and the `v0.5.4` tag

## Checklist
- [x] No raw dicts crossing layer boundaries (n/a — docs only)
- [x] No `os.getenv()` outside `config/settings.py` (n/a — docs only)
- [x] External imports are lazy (n/a — docs only)